### PR TITLE
Composer integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
         "php": ">=5.3.2",
         "sonata/admin-bundle": "*",
         "symfony/framework-bundle": "2.*",
-        "symfony/security-bundle": "2.*"
+        "symfony/security-bundle": "2.*",
+        "symfony/mongodb-odm-bundle": "2.*",
+        "doctrine/mongodb": "dev-master",
+        "doctrine/mongodb-odm": "dev-master",
     },
     "autoload": {
         "psr-0": { "Sonata\\DoctrineMongoDBAdminBundle": "" }


### PR DESCRIPTION
The package name is: **sonata/doctrine-mongodb-admin-bundle**
I've added three requirements:

"symfony/mongodb-odm-bundle": "2.*"
"doctrine/mongodb": "dev-master"
"doctrine/mongodb-odm": "dev-master"

If everthing seems ok to you the next step is to add the bundle to packagist...and see if everything is ok.
When you add it let me know, so I can do some tests with the symfony standard distro.
