### PR TITLE
fix mongodb-odm-bundle dependance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "sonata-project/admin-bundle": "*",
         "symfony/framework-bundle": "2.*",
         "symfony/security-bundle": "2.*",
-        "symfony/mongodb-odm-bundle": "2.*",
+        "doctrine/mongodb-odm-bundle": "2.*",
         "doctrine/mongodb": "dev-master",
         "doctrine/mongodb-odm": "dev-master"
     },


### PR DESCRIPTION
Hi,

When I try to update composer, I've got this error :

```
$ php composer.phar update
Updating dependencies
  - Installing symfony/mongodb-odm-bundle (2.0.x-dev)
    Cloning v2.0.1



  [RuntimeException]                                                                                                                    
  Failed to clone http://github.com/symfony/DoctrineMongoDBBundle.git via git, https and http protocols, aborting.                      

  - git://github.com/symfony/DoctrineMongoDBBundle.git                                                                                  
    fatal: remote error:                                                                                                                
      Repository not found.                                                                                                             

  - https://github.com/symfony/DoctrineMongoDBBundle.git                                                                                
    fatal: https://github.com/symfony/DoctrineMongoDBBundle.git/info/refs not found: did you run git update-server-info on the server?  

  - http://github.com/symfony/DoctrineMongoDBBundle.git                                                                                 
    fatal: http://github.com/symfony/DoctrineMongoDBBundle.git/info/refs not found: did you run git update-server-info on the server?   
```

The dependence "symfony/mongodb-odm-bundle" doesn't exist anymore.
