### PR TITLE
Removed csrf_protection option from FilterTypeGuesser

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -86,9 +86,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             case 'bigint':
             case 'smallint':
                 $options['field_type'] = 'number';
-                $options['field_options'] = array(
-                    'csrf_protection' => false
-                );
 
                 return new TypeGuess('doctrine_mongo_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'id':


### PR DESCRIPTION
Setting the csrf_protection option produces an exception in SonataAdminBundle GRIDs
