### PR TITLE
Fix find for numeric id in ModelManager

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -147,7 +147,12 @@ class ModelManager implements ModelManagerInterface
     public function find($class, $id)
     {
         if (is_numeric($id)) {
-            $id = intval($id);
+
+            $value = $this->documentManager->getRepository($class)->find(intval($id));
+
+            if (!empty($value)) {
+                return $value;
+            }
         }
 
         return $this->documentManager->getRepository($class)->find($id);


### PR DESCRIPTION
Add fallback to fetch by id as string if id value is_numeric but result null. 
Usefull if Mongo ObjectId does not contain letter as 500051249896307640000005 for example is a valid mongo ObjectId
