### PR TITLE
added missing function getUrlsafeIdentifier required by interface

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -279,6 +279,14 @@ class ModelManager implements ModelManagerInterface
 
         return implode('-', $values);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function getUrlsafeIdentifier($entity)
+    {
+        return $this->getNormalizedIdentifier($entity);
+    }
 
     /**
      * @param $class


### PR DESCRIPTION
Fatal error: Class Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Sonata\AdminBundle\Model\ModelManagerInterface::getUrlsafeIdentifier)
