### PR TITLE
Add support for simple id associations, non-MongoId ids, and multiple documents to ModelFilter; copy changes to FormContractor and DatagridBuilder from SonataDoctrineORMAdminBundle

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -54,17 +54,19 @@ class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->setAdmin($admin);
 
         if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            $metadata = $admin->getModelManager()->getMetadata($admin->getClass());
+            list($metadata, $lastPropertyName, $parentAssociationMappings) = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
 
             // set the default field mapping
-            if (isset($metadata->fieldMappings[$fieldDescription->getName()])) {
-                $fieldDescription->setFieldMapping($metadata->fieldMappings[$fieldDescription->getName()]);
-
-                // set the default association mapping
-                if (isset($metadata->fieldMappings[$fieldDescription->getName()]['reference'])) {
-                    $fieldDescription->setAssociationMapping($metadata->fieldMappings[$fieldDescription->getName()]);
-                }
+            if (isset($metadata->fieldMappings[$lastPropertyName])) {
+                $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$fieldDescription->getName()]));
             }
+
+            // set the default association mapping
+            if (isset($metadata->associationMappings[$lastPropertyName])) {
+                $fieldDescription->setOption('association_mapping', $fieldDescription->getOption('association_mapping', $metadata->fieldMappings[$lastPropertyName]));
+            }
+
+            $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $parentAssociationMappings));
         }
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));

--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -47,9 +47,11 @@ class FormContractor implements FormContractorInterface
             // set the default field mapping
             if (isset($metadata->fieldMappings[$fieldDescription->getName()])) {
                 $fieldDescription->setFieldMapping($metadata->fieldMappings[$fieldDescription->getName()]);
+            }
 
-                // set the default association mapping
-                $fieldDescription->setAssociationMapping($metadata->fieldMappings[$fieldDescription->getName()]);
+            // set the default association mapping
+            if (isset($metadata->associationMappings[$fieldDescription->getName()])) {
+              $fieldDescription->setAssociationMapping($metadata->associationMappings[$fieldDescription->getName()]);
             }
         }
 
@@ -90,51 +92,43 @@ class FormContractor implements FormContractorInterface
      */
     public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription)
     {
-        $options = array();
-        $options['sonata_field_description'] = $fieldDescription;
+      $options                             = array();
+      $options['sonata_field_description'] = $fieldDescription;
 
-        if ($type == 'sonata_type_model') {
-            $options['class'] = $fieldDescription->getTargetEntity();
-            $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
+      if ($type == 'sonata_type_model' || $type == 'sonata_type_model_list') {
 
-            switch ($fieldDescription->getMappingType()) {
-                case ClassMetadataInfo::ONE:
-                    break;
-                case ClassMetadataInfo::MANY:
-                    $options['multiple'] = true;
-                    $options['parent'] = 'choice';
-                    break;
-            }
-
-            if ($fieldDescription->getOption('edit') == 'list') {
-                $options['parent'] = 'text';
-
-                if (!array_key_exists('required', $options)) {
-                    $options['required'] = false;
-                }
-            }
-        } else if ($type == 'sonata_type_admin') {
-
-            if (!$fieldDescription->getAssociationAdmin()) {
-                throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
-            }
-        } else if ($type == 'sonata_type_collection') {
-
-            throw new \RuntimeException('Type "sonata_type_collection" is not yet implemented.');
-
-            if (!$fieldDescription->getAssociationAdmin()) {
-                throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
-            }
-
-            $options['type'] = 'sonata_type_admin';
-            $options['modifiable'] = true;
-            $options['type_options'] = array(
-                'sonata_field_description' => $fieldDescription,
-                'data_class' => $fieldDescription->getAssociationAdmin()->getClass()
-            );
+        if ($fieldDescription->getOption('edit') == 'list') {
+          throw new \LogicException('The ``sonata_type_model`` type does not accept an ``edit`` option anymore, please review the UPGRADE-2.1.md file from the SonataAdminBundle');
         }
 
-        return $options;
+        $options['class']         = $fieldDescription->getTargetEntity();
+        $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
+
+      } else if ($type == 'sonata_type_admin') {
+
+        if (!$fieldDescription->getAssociationAdmin()) {
+          throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
+        }
+
+        $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
+        $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
+
+      } else if ($type == 'sonata_type_collection') {
+
+        if (!$fieldDescription->getAssociationAdmin()) {
+          throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
+        }
+
+        $options['type']         = 'sonata_type_admin';
+        $options['modifiable']   = true;
+        $options['type_options'] = array(
+            'sonata_field_description' => $fieldDescription,
+            'data_class'               => $fieldDescription->getAssociationAdmin()->getClass()
+        );
+
+      }
+
+      return $options;
     }
 
 }


### PR DESCRIPTION
Add support for "simple" (as well as ObjectId) references in one- and many-associations to ModelFilter; bring in some changes to DataGridBuilder and FormContractor from SonataDoctrineORMAdminBundle.
