### PR TITLE
Show relation in list view even if no admin association is set (fixes #31)

### DIFF
--- a/Resources/views/CRUD/list_mongo_one.html.twig
+++ b/Resources/views/CRUD/list_mongo_one.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
 
 {% block field %}
-    {% if field_description.hasAssociationAdmin and field_description.associationadmin.id(value) %}
+    {% if value %}
         {% if field_description.hasAssociationAdmin and field_description.associationadmin.isGranted('EDIT') and field_description.associationadmin.hasRoute('edit') %}
             <a href="{{ field_description.associationadmin.generateObjectUrl('edit', value) }}">{{ value|render_relation_element(field_description) }}</a>
         {% else %}


### PR DESCRIPTION
When a many to one relation is defined on a Doctrine (MongoDB) Document, the related document is never shown in the list view.

In the following example, category is a property of a Post that contains a Category object. 

``` php
    protected function configureListFields(ListMapper $listMapper)
    {
        $listMapper->add('category');
    }
```

I expect the string representation of the category to be shown in the list view. Instead nothing is shown.
