### PR TITLE
Added support for doctrine collection type to TypeGuesser

### DIFF
--- a/Guesser/TypeGuesser.php
+++ b/Guesser/TypeGuesser.php
@@ -54,6 +54,7 @@ class TypeGuesser extends AbstractTypeGuesser
         }
 
         switch ($metadata->getTypeOfField($propertyName)) {
+            case 'collection':
             case 'hash':
             case 'array':
               return new TypeGuess('array', array(), Guess::HIGH_CONFIDENCE);


### PR DESCRIPTION
The doctrine mongodb type collection was not supported in the TypeGuesser.
