### PR TITLE
Required parameter $alias wasn't passed to createQueryBuilder method.

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -218,7 +218,7 @@ class ModelManager implements ModelManagerInterface
     {
         $repository = $this->getEntityManager()->getRepository($class);
 
-        return $repository->createQueryBuilder();
+        return $repository->createQueryBuilder($alias);
     }
 
     /**


### PR DESCRIPTION
Required parameter $alias wasn't passed to createQueryBuilder method.
