### PR TITLE
Return proxy query instead of doctrine query builder

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -13,7 +13,6 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Builder;
 
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
-use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -121,15 +120,12 @@ class DatagridBuilder implements DatagridBuilderInterface
      */
     public function getBaseDatagrid(AdminInterface $admin, array $values = array())
     {
-        $queryBuilder = $admin->createQuery();
-
-        $query = new ProxyQuery($queryBuilder);
         $pager = new Pager;
         $pager->setCountColumn($admin->getModelManager()->getIdentifierFieldNames($admin->getClass()));
 
         $formBuilder = $this->formFactory->createNamedBuilder('filter', 'form', array(), array('csrf_protection' => false));
 
-        return new Datagrid($query, $admin->getList(), $pager, $formBuilder, $values);
+        return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }
 
 }

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -182,7 +182,7 @@ class ModelManager implements ModelManagerInterface
     }
 
     /**
-     * @return \Doctrine\ORM\EntityManager
+     * @return DocumentManager
      */
     public function getEntityManager()
     {
@@ -212,13 +212,13 @@ class ModelManager implements ModelManagerInterface
     /**
      * @param $class
      * @param string $alias
-     * @return \Doctrine\ODM\MongoDB\Query\Builder
+     * @return ProxyQuery
      */
     public function createQuery($class, $alias = 'o')
     {
         $repository = $this->getEntityManager()->getRepository($class);
 
-        return $repository->createQueryBuilder();
+        return new ProxyQuery($repository->createQueryBuilder());
     }
 
     /**
@@ -227,7 +227,7 @@ class ModelManager implements ModelManagerInterface
      */
     public function executeQuery($query)
     {
-        if ($query instanceof QueryBuilder) {
+        if ($query instanceof Builder) {
             return $query->getQuery()->execute();
         }
 
@@ -369,7 +369,7 @@ class ModelManager implements ModelManagerInterface
     }
 
     /**
-     * @param sring $class
+     * @param string $class
      * @return array
      */
     public function getDefaultSortValues($class)


### PR DESCRIPTION
I have created a new pull request because I couldn't get the commits squashed.

This was also fixed in doctrine orm a while ago: 
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/commit/e143a23c528d80241f7f186a997386854fc7d759 

This was required to make the admin extensions work for mongodb admin.

I fixed the instanceof check in executeQuery() too.
