### PR TITLE
Switch KPNMenuBundle to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sonata-project/admin-bundle": "2.2.*@dev",
         "sonata-project/block-bundle": "2.2.*@dev",
         "symfony/symfony": ">=2.2,<2.3",
-        "knplabs/knp-menu-bundle": "1.1.x-dev"
+        "knplabs/knp-menu-bundle": "~1.1"
     },
     "autoload": {
         "psr-0": {"Sonata\\DoctrineMongoDBAdminBundle": ""}


### PR DESCRIPTION
Is it possible to switch the KNPMenuBundle dependency to the stable version, just like the other admin-bundles? I'm having a conflict with my application relying on stable versions.

Thanx!
