### PR TITLE
Fixed typo in example code

### DIFF
--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -152,7 +152,7 @@ or not.
                             return;
                         }
 
-                        queryBuilder
+                        $queryBuilder
                             ->field('end')
                             ->lt(new \DateTime());
 


### PR DESCRIPTION
There was the "$" sign missing for the queryBuilder variable.
