### PR TITLE
Exception has been throw when $id is an integer in function ModelFilter::fixIdentifier

### DIFF
--- a/Filter/ModelFilter.php
+++ b/Filter/ModelFilter.php
@@ -105,7 +105,12 @@ class ModelFilter extends Filter
      */
     protected static function fixIdentifier($id)
     {
-        return @($id == new \MongoId($id)) ? new \MongoId($id) : $id;
+        $mongo_id = new MongoId($id);
+        if ($mongo_id->{'$id'} == $id){
+            return $mongo_id;
+        }else{
+            return $id;
+        }
     }
 
     /**


### PR DESCRIPTION
If $id is an integer, then the construct of \MongoId will throw an exception because it could not be converted. So I add a an error control operator, which means If convert is success,then return it,otherwise return origin $id.
