### PR TITLE
Installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For contribution to the documentation you cand find it on [Resources/doc](https:
 **Warning**: documentation files are not rendering correctly in Github (reStructuredText format)
 and some content might be broken or hidden, make sure to read raw files.
 
-**Google Groups**: For questions and proposals you can post on this google groups
+**Google Groups**: For questions and proposals you can post on these google groups
 
-* [Sonata Users](https://groups.google.com/group/sonata-users): Only for user questions
-* [Sonata Devs](https://groups.google.com/group/sonata-devs): Only for devs
+* [Sonata Users](https://groups.google.com/group/sonata-users): For questions on how to use Sonata bundles on your project
+* [Sonata Devs](https://groups.google.com/group/sonata-devs): For questions regarding the development of Sonata bundles

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -3,10 +3,10 @@ Doctrine MongoDB Admin Bundle
 
 The ``Doctrine MongoDB ODM Admin`` provides services to work with the ``Admin Bundle`` and the ``Doctrine Project``.
 
-**Google Groups**: For questions and proposals you can post on this google groups
+**Google Groups**: For questions and proposals you can post on these google groups
 
-* `Sonata Users <https://groups.google.com/group/sonata-users>`_: Only for user questions
-* `Sonata Devs <https://groups.google.com/group/sonata-devs>`_: Only for devs
+* `Sonata Users <https://groups.google.com/group/sonata-users>`_: For questions on how to use Sonata bundles on your project
+* `Sonata Devs <https://groups.google.com/group/sonata-devs>`_: For questions regarding the development of Sonata bundles
 
 Reference Guide
 ---------------

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -1,16 +1,30 @@
 Installation
 ============
 
-First install the Sonata Admin Bundle which provides Core functionalities.
+SonataDoctrineMongoDBAdminBundle is part of a set of bundles aimed at abstracting 
+storage connectivity for SonataAdminBundle. As such, SonataDoctrineMongoDBAdminBundle
+depends on SonataAdminBundle, and will not work without it. 
+
+.. note::
+    These installation instructions are meant to be used only as part of SonataAdminBundle's
+    installation process, which is documented `here <http://sonata-project.org/bundles/admin/master/doc/reference/installation.html>`_.
 
 Download bundles
 ----------------
 
-Use composer ::
+Use composer:
+
+.. code-block:: bash
 
     php composer.phar require sonata-project/doctrine-mongodb-admin-bundle
 
-Version constraint: dev-master
+You'll be asked to type in a version constraint. 'dev-master' will usually get you the latest, bleeding edge
+version. Check `packagist <https://packagist.org/packages/sonata-project/doctrine-mongodb-admin-bundle>`_
+for stable and legacy versions:
+
+.. code-block:: bash
+
+    Please provide a version constraint for the sonata-project/doctrine-mongodb-admin-bundle requirement: dev-master
 
 Configuration
 -------------
@@ -26,7 +40,13 @@ files:
     {
         return array(
             // ...
+            // set up basic sonata requirements
+            // ...
             new Sonata\DoctrineMongoDBAdminBundle\SonataDoctrineMongoDBAdminBundle(),
             // ...
         );
     }
+
+.. note::
+    Don't forget that, as part of `SonataAdminBundle's installation instructions <http://sonata-project.org/bundles/admin/master/doc/reference/installation.html>`_,
+    you need to enable additional bundles on AppKernel.php


### PR DESCRIPTION
Install instructions updated, similar to the ones existing on the other 3 sonata admin abstractions bundles (som of the PRs are pending approval).
Made them clearer regarding some details that might be confusing for new users. Also made the google groups description more accurate.

Part of https://github.com/sonata-project/SonataAdminBundle/issues/1520
