### PR TITLE
Changed deprecated method to new one

### DIFF
--- a/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
     {{ value|render_relation_element(sonata_admin.field_description) }}
 {% elseif sonata_admin.edit == 'inline' %}
     {% for field_description in sonata_admin.field_description.associationadmin.formfielddescriptions %}
-        {{ form_row(form.getChild(field_description.name))}}
+        {{ form_row(form.children[field_description.name])}}
     {% endfor %}
 {% else %}
     <div id="field_container_{{ id }}">


### PR DESCRIPTION
In symfony 2.3 FormView.getChild has been removed, so worked no more. Changed it as was advised in doc.
