### PR TITLE
Batch operation doesn't trigger doctrine events

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -282,7 +282,11 @@ class ModelManager implements ModelManagerInterface
      */
     public function batchDelete($class, ProxyQueryInterface $queryProxy)
     {
-        $queryBuilder = $queryProxy->getQueryBuilder()->remove()->getQuery()->execute();
+        /** @var Query $queryBuilder */
+        $queryBuilder = $queryProxy->getQuery();
+        foreach ($queryBuilder->execute() as $object) {
+            $this->documentManager->remove($object);
+        }
 
         $this->documentManager->flush();
         $this->documentManager->clear();


### PR DESCRIPTION
Batch operations doesn't trigger doctrine(_mongodb) events, what is a huge issue, if you have `preRemove`-events to bring the data model back into a consistent state.
