### PR TITLE
fix Fatal error: Cannot use Object as array,  is an Object not an array

### DIFF
--- a/Util/ObjectAclManipulator.php
+++ b/Util/ObjectAclManipulator.php
@@ -52,7 +52,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
             $objectIds = array();
 
             foreach ($qb->getQuery()->iterate() as $row) {
-                $objectIds[]      = ObjectIdentity::fromDomainObject($row[0]);
+                $objectIds[]      = ObjectIdentity::fromDomainObject($row);
                 $objectIdIterator = new \ArrayIterator($objectIds);
 
                 // detach from Doctrine, so that it can be Garbage-Collected immediately


### PR DESCRIPTION
I have had the experience that the $row variable is the Document Object and not an array, if I try to run this command I get an error similar to this:

Fatal error: Cannot use object of type Application\Networking\InitCmsBundle\Document\User as array 
