### PR TITLE
Replace associationMappings to fieldMappings for association property at Guesser

### DIFF
--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -40,7 +40,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
         $options['parent_association_mappings'] = $parentAssociationMappings;
 
         if ($metadata->hasAssociation($propertyName)) {
-            $mapping = $metadata->associationMappings[$propertyName];
+            $mapping = $metadata->fieldMappings[$propertyName];
 
             switch ($mapping['type']) {
                 case ClassMetadataInfo::ONE:

--- a/Guesser/TypeGuesser.php
+++ b/Guesser/TypeGuesser.php
@@ -31,7 +31,7 @@ class TypeGuesser extends AbstractTypeGuesser
         list($metadata, $propertyName, $parentAssociationMappings) = $ret;
 
         if ($metadata->hasAssociation($propertyName)) {
-            $mapping = $metadata->associationMappings[$propertyName];
+            $mapping = $metadata->fieldMappings[$propertyName];
 
             switch ($mapping['type']) {
                 case ClassMetadataInfo::ONE:


### PR DESCRIPTION
Without this fix for property:

``` php
/**
* @MongoDB\ReferenceOne(targetDocument="ArticleCategory", nullable=true)
*/
protected $parent;
```

I have error notice:

``` html
Notice: Undefined index: parent in /var/www/exercise/vendor/sonata-project/doctrine-mongodb-admin-bundle/Sonata/DoctrineMongoDBAdminBundle/Guesser/TypeGuesser.php on line 34

Notice: Undefined index: parent in /var/www/exercise/vendor/sonata-project/doctrine-mongodb-admin-bundle/Sonata/DoctrineMongoDBAdminBundle/Guesser/FilterTypeGuesser.php on line 43
```
