### PR TITLE
sync global_search to DatagridBuilder from orm

### DIFF
--- a/Builder/DatagridBuilder.php
+++ b/Builder/DatagridBuilder.php
@@ -69,6 +69,10 @@ class DatagridBuilder implements DatagridBuilderInterface
             // set the default field mapping
             if (isset($metadata->fieldMappings[$lastPropertyName])) {
                 $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$lastPropertyName]));
+
+                if ($metadata->fieldMappings[$lastPropertyName]['type'] == 'string') {
+                    $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
+                }
             }
 
             // set the default association mapping


### PR DESCRIPTION
just works because mapping for string types is same between orm and odm admins
