### PR TITLE
Using db.XX.count in pager to count results 

### DIFF
--- a/Datagrid/Pager.php
+++ b/Datagrid/Pager.php
@@ -36,8 +36,7 @@ class Pager extends BasePager
             $countQuery->setParameters($this->getParameters());
         }
 
-        // TODO: use map/reduce for that
-        return $this->getQuery()->execute()->count();
+        return $countQuery->count()->getQuery()->execute();
     }
 
     /**


### PR DESCRIPTION
Closes #103

Before: 

```
db.book.find().sort({ "title.name": 1 });
db.book.find().skip(0).limit(25).sort({ "title.name": 1 });
```

After:

```
db.book.count();
db.book.find().skip(0).limit(25).sort({ "title.name": 1 });
```
