### PR TITLE
Remove unused "entity_manager" option from configuration

### DIFF
--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -10,9 +10,6 @@ Full Configuration Options
 .. code-block:: yaml
 
     sonata_doctrine_mongo_db_admin:
-        # default value is null, so doctrine uses the value defined in the configuration
-        entity_manager: ~
-
         templates:
             form:
                 - SonataDoctrineMongoDBAdminBundle:Form:form_admin_fields.html.twig


### PR DESCRIPTION
`entity_manager` option is not supported in `sonata_doctrine_mongo_db_admin` configuration block.
