### PR TITLE
Fix travis mongodb install command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 services: mongodb
 
 before_script:
-  - pecl -q install -f mongo && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+  - yes '' | pecl -q install -f mongo && echo "extension=mongo.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source
   - composer install --dev
 


### PR DESCRIPTION
Fixes the `Build with Cyrus SASL (MongoDB Enterprise Authentication) support? [no] :` prompt.

Waiting for travis CI build to check if the update is correct.
