### PR TITLE
Fixed empty btn-group on edit mongo one

### DIFF
--- a/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -16,6 +16,10 @@ file that was distributed with this source code.
         {{ form_row(form[field_description.name])}}
     {% endfor %}
 {% else %}
+    {% set display_btn_list = sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
+    {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+    {% set display_btn_delete = sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_delete %}
+
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
@@ -42,32 +46,34 @@ file that was distributed with this source code.
         {% endif %}
 
         <span id="field_actions_{{ id }}" class="field-actions">
-            <span class="btn-group">
-                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
-                <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
-                    onclick="return start_field_dialog_form_list_{{ id }}(this);"
-                    class="btn sonata-ba-action"
-                    title="{{ btn_list|trans({}, btn_catalogue) }}"
-                    >
-                    <i class="icon-list"></i>
-                    {{ btn_list|trans({}, btn_catalogue) }}
-                </a>
+            {% if display_btn_list or display_btn_add %}
+                <span class="btn-group">
+                    {% if display_btn_list %}
+                        <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
+                            onclick="return start_field_dialog_form_list_{{ id }}(this);"
+                            class="btn sonata-ba-action"
+                            title="{{ btn_list|trans({}, btn_catalogue) }}"
+                            >
+                            <i class="icon-list"></i>
+                            {{ btn_list|trans({}, btn_catalogue) }}
+                        </a>
+                    {% endif %}
+
+                    {% if display_btn_add %}
+                        <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
+                            onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                            class="btn sonata-ba-action"
+                            title="{{ btn_add|trans({}, btn_catalogue) }}"
+                            >
+                            <i class="icon-plus"></i>
+                            {{ btn_add|trans({}, btn_catalogue) }}
+                        </a>
+                    {% endif %}
+                </span>
             {% endif %}
 
-                {% if sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-                <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
-                    onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                    class="btn sonata-ba-action"
-                    title="{{ btn_add|trans({}, btn_catalogue) }}"
-                    >
-                    <i class="icon-plus"></i>
-                    {{ btn_add|trans({}, btn_catalogue) }}
-                </a>
-            {% endif %}
-            </span>
-
-            <span class="btn-group">
-                {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_delete %}
+            {% if display_btn_delete %}
+                <span class="btn-group">
                     <a  href=""
                         onclick="return remove_selected_element_{{ id }}(this);"
                         class="btn sonata-ba-action"
@@ -76,8 +82,8 @@ file that was distributed with this source code.
                         <i class="icon-off"></i>
                         {{ btn_delete|trans({}, btn_catalogue) }}
                     </a>
-                {% endif %}
-            </span>
+                </span>
+            {% endif %}
         </span>
 
         <div class="container sonata-ba-modal sonata-ba-modal-edit-one-to-one" style="display: none" id="field_dialog_{{ id }}">


### PR DESCRIPTION
When mongo one field has no list/create/delete buttons related, template outputs 

```
<span class="btn-group"></span>
```

and .btn-group element even empty occupy space. 

This change ensure that .btn-group element is added only with corresponding button(s).
