### PR TITLE
Fixed inline table editing for mongo collection type

### DIFF
--- a/Resources/views/CRUD/edit_mongo_collection.html.twig
+++ b/Resources/views/CRUD/edit_mongo_collection.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                 <table class="table table-bordered">
                     <thead>
                     <tr>
-                        {% for field_name, nested_field in form.children[0].children %}
+                        {% for field_name, nested_field in form.children|first.children %}
                             {% if field_name == '_delete' %}
                                 <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
                             {% else %}


### PR DESCRIPTION
Possibly fixes #123.
The main point of the fix is that sonata uses zero element of the collection to render table header. But zero element may not exist. So I use **first** filter to get actually first element, whichever index it has.
