### PR TITLE
Added class sonata-ba-field-error for activate tab

### DIFF
--- a/Resources/views/CRUD/edit_mongo_collection.html.twig
+++ b/Resources/views/CRUD/edit_mongo_collection.html.twig
@@ -46,7 +46,7 @@ file that was distributed with this source code.
                                         {{ form_widget(nested_field) }}
                                     {% endif %}
                                     {% if nested_field.vars.errors|length > 0 %}
-                                        <div class="help-inline sonata-ba-field-error-messages">
+                                        <div class="help-inline sonata-ba-field-error sonata-ba-field-error-messages">
                                             {{ form_errors(nested_field) }}
                                         </div>
                                     {% endif %}


### PR DESCRIPTION
Sonata js activate tab with error by "sonata-ba-field-error" css class.
See this - https://github.com/sonata-project/SonataAdminBundle/blob/master/Resources/public/Admin.js#L361
