### PR TITLE
Support filters with CONDITION_OR

### DIFF
--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -39,12 +39,21 @@ class StringFilter extends Filter
 
         $data['type'] = isset($data['type']) && !empty($data['type']) ? $data['type'] : ChoiceType::TYPE_CONTAINS;
 
+        $obj = $queryBuilder;
+        if ($this->condition == self::CONDITION_OR) {
+            $obj = $queryBuilder->expr();
+        }
+
         if ($data['type'] == ChoiceType::TYPE_EQUAL) {
-            $queryBuilder->field($field)->equals($data['value']);
+            $obj->field($field)->equals($data['value']);
         } elseif ($data['type'] == ChoiceType::TYPE_CONTAINS) {
-            $queryBuilder->field($field)->equals(new \MongoRegex(sprintf('/%s/i', $data['value'])));
+            $obj->field($field)->equals(new \MongoRegex(sprintf('/%s/i', $data['value'])));
         } elseif ($data['type'] == ChoiceType::TYPE_NOT_CONTAINS) {
-            $queryBuilder->field($field)->not(new \MongoRegex(sprintf('/%s/i', $data['value'])));
+            $obj->field($field)->not(new \MongoRegex(sprintf('/%s/i', $data['value'])));
+        }
+
+        if ($this->condition == self::CONDITION_OR) {
+            $queryBuilder->addOr($obj);
         }
 
         $this->active = true;

--- a/Tests/Filter/FilterWithQueryBuilderTest.php
+++ b/Tests/Filter/FilterWithQueryBuilderTest.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 abstract class FilterWithQueryBuilderTest extends \PHPUnit_Framework_TestCase
 {
     private $queryBuilder = null;
+    private $expr = null;
 
     public function setUp()
     {
@@ -24,6 +25,19 @@ abstract class FilterWithQueryBuilderTest extends \PHPUnit_Framework_TestCase
                 ->expects($this->any())
                 ->method('field')
                 ->will($this->returnSelf())
+        ;
+        $this->expr = $this->getMockBuilder('Doctrine\ODM\MongoDB\Query\Expr')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->expr
+            ->expects($this->any())
+            ->method('field')
+            ->will($this->returnSelf())
+        ;
+        $this->queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->will($this->returnValue($this->expr))
         ;
     }
 

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\Filter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\StringFilter;
 
 class StringFilterTest extends FilterWithQueryBuilderTest
@@ -89,6 +90,25 @@ class StringFilterTest extends FilterWithQueryBuilderTest
         $builder = new ProxyQuery($this->getQueryBuilder());
 
         $filter->apply($builder, array('type' => ChoiceType::TYPE_EQUAL, 'value' => 'asd'));
+        $this->assertEquals(true, $filter->isActive());
+    }
+
+    public function testOr()
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', array('format' => '%s'));
+        $filter->setCondition(Filter::CONDITION_OR);
+
+        $builder = new ProxyQuery($this->getQueryBuilder());
+        $builder->getQueryBuilder()->expects($this->once())->method('addOr');
+        $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => ChoiceType::TYPE_CONTAINS));
+        $this->assertEquals(true, $filter->isActive());
+
+        $filter->setCondition(Filter::CONDITION_AND);
+
+        $builder = new ProxyQuery($this->getQueryBuilder());
+        $builder->getQueryBuilder()->expects($this->never())->method('addOr');
+        $filter->filter($builder, 'alias', 'field', array('value' => 'asd', 'type' => ChoiceType::TYPE_CONTAINS));
         $this->assertEquals(true, $filter->isActive());
     }
 }


### PR DESCRIPTION
This PR adds support for StringFilters with CONDITION_OR. These are required for correct filtering in fields of type sonata_type_model_autocomplete with multiple properties.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -