### PR TITLE
[Templating] [Twig] Sf3.0 support : Changing render from tag to function

### DIFF
--- a/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -24,12 +24,12 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.admin.id(sonata_admin.value) %}
-                    {% render url('sonata_admin_short_object_information', {
+                    {{ render(url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
-                    )%}
+                    ))}}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -51,12 +51,12 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% render url('sonata_admin_short_object_information', {
+                    {{ render(url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
-                    )%}
+                    ))}}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         }
     ],
     "require": {
-        "doctrine/mongodb-odm-bundle": "~3.0@dev",
-        "sonata-project/admin-bundle": "dev-master",
-        "symfony/security-acl": "~2.2|~3.0@dev"
+        "doctrine/mongodb-odm-bundle": "~3.0",
+        "sonata-project/admin-bundle": "~2.3.0",
+        "symfony/security-acl": "~2.2|~3.0"
     },
     "require-dev": {
         "jmikola/geojson": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | none
| License       | MIT
| Doc PR        | -

Since Sf3.0 Twig `render` tag became a function.
Updated some templates that were using render as a tag.