### PR TITLE
Fixes a wrong property name on FormContractor

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -19,6 +19,14 @@ use Symfony\Component\Form\FormFactoryInterface;
 
 class FormContractor implements FormContractorInterface
 {
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @deprecated
+     */
     protected $fieldFactory;
 
     /**


### PR DESCRIPTION
See the same [PR for doctrine-orm-admin-bundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/588).
I quote:
### Changelog

``` markdown
### Fixed
- Fix wrong property name on `FormContractor`
```
### Subject

The other is never used. As a protected one, I keep it for BC.
Because of the deprecation, this should be delivered as a new minor.
