### PR TITLE
adds sllh/php-cs-fixer-styleci-bridge to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "jmikola/geojson": "^1.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
     },
     "provide": {


### PR DESCRIPTION

## Changelog

```markdown
### Added
- Added `sllh/php-cs-fixer-styleci-bridge` to dev dependencies
```

## Subject

The php-cs-fixer-styleci-bridge bundle is required by the .php_cs config but is not required in composer.json