### PR TITLE
adds support for FQCN form type referencing to FormContractor

### DIFF
--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
+
+/**
+ * @author ju1ius <ju1ius@laposte.net>
+ */
+class FormContractorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var FormContractor
+     */
+    private $formContractor;
+
+    protected function setUp()
+    {
+        $this->formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+
+        $this->formContractor = new FormContractor($this->formFactory);
+    }
+
+    public function testDefaultOptionsForSonataFormTypes()
+    {
+        $admin = $this->getMockBuilder('Sonata\AdminBundle\Admin\AdminInterface')->getMock();
+        $modelManager = $this->getMockBuilder('Sonata\AdminBundle\Model\ModelManagerInterface')->getMock();
+        $modelClass = 'FooEntity';
+
+        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getClass')->willReturn($modelClass);
+
+        $fieldDescription = $this->getMockBuilder('Sonata\AdminBundle\Admin\FieldDescriptionInterface')->getMock();
+        $fieldDescription->method('getAdmin')->willReturn($admin);
+        $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
+        $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+
+        $modelTypes = array(
+            'sonata_type_model',
+            'sonata_type_model_list',
+            'sonata_type_model_hidden',
+            'sonata_type_model_autocomplete',
+        );
+        $adminTypes = array('sonata_type_admin');
+        $collectionTypes = array('sonata_type_collection');
+        // NEXT_MAJOR: Use only FQCNs when dropping support for Symfony <2.8
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            array_push(
+                $modelTypes,
+                'Sonata\AdminBundle\Form\Type\ModelType',
+                'Sonata\AdminBundle\Form\Type\ModelTypeList',
+                'Sonata\AdminBundle\Form\Type\ModelHiddenType',
+                'Sonata\AdminBundle\Form\Type\ModelAutocompleteType'
+            );
+            $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
+            $collectionTypes[] = 'Sonata\CoreBundle\Form\Type\CollectionType';
+        }
+
+        // model types
+        foreach ($modelTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['class']);
+            $this->assertSame($modelManager, $options['model_manager']);
+        }
+
+        // admin type
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE);
+        foreach ($adminTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['data_class']);
+            $this->assertSame(false, $options['btn_add']);
+            $this->assertSame(false, $options['delete']);
+        }
+
+        // collection type
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::MANY);
+        foreach ($collectionTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
+            $this->assertSame($fieldDescription, $options['sonata_field_description']);
+            $this->assertSame('sonata_type_admin', $options['type']);
+            $this->assertSame(true, $options['modifiable']);
+            $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
+            $this->assertSame($modelClass, $options['type_options']['data_class']);
+        }
+    }
+}


### PR DESCRIPTION
I am targetting this branch, because this is a BC bugfix

Will close https://github.com/sonata-project/SonataAdminBundle/issues/3976 when [doctrine-orm-admin-bundle PR](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/598) is also merged.
## Changelog

``` markdown
### Fixed
- Fix `FormContractor::getDefaultOptions` not checking against form types FQCNs
```
## Subject

`FormContractor::getDefaultOptions` didn't check against form types FQCNs, causing the default options not to be set when using the Symfony 3 way:

``` php
$formMapper->add('foo', ModelType::class);
```

See related admin-bundle issue at https://github.com/sonata-project/SonataAdminBundle/issues/3976
