### PR TITLE
Add php 7.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ matrix:
       env: SONATA_ADMIN=dev-master@dev
     - php: '5.6'
       env: SYMFONY_DEPRECATIONS_HELPER=0
+    - php: '7.0'
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/.travis/before_install_test.sh
+++ b/.travis/before_install_test.sh
@@ -14,5 +14,7 @@ fi
 composer self-update --stable
 sed --in-place "s/\"dev-master\":/\"dev-${TRAVIS_COMMIT}\":/" composer.json
 
+if [ "$MONGODB_VERSION" != "" ]; then pecl install -f mongodb-$MONGODB_VERSION; fi
+if [ "$ADAPTER_VERSION" != "" ]; then composer require "alcaeus/mongo-php-adapter=$ADAPTER_VERSION" --ignore-platform-reqs; fi
 if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:$SYMFONY" --no-update; fi;
 if [ "$SONATA_ADMIN" != "" ]; then composer require "sonata-project/admin-bundle:$SONATA_ADMIN" --no-update; fi;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3",
+        "php": "^5.3 || ^7.0",
         "doctrine/mongodb-odm": "^1.0",
         "doctrine/mongodb-odm-bundle": "^3.0",
         "sonata-project/admin-bundle": "^3.1"
@@ -26,6 +26,9 @@
         "jmikola/geojson": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0"
+    },
+    "suggest": {
+        "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"


### PR DESCRIPTION
I am targetting this branch, because php 7 should be supported for sonata bundle ^3.0

Relates #168
Replaces #170

## Changelog

```markdown
### Added
- Added php 7.0 support
```
## Subject
Added php 7.0 support with travis build using `alcaeus/mongo-php-adapter`. The same was done for https://github.com/doctrine/mongodb-odm after the adapter was released.