### PR TITLE
Correct use of render function for Symfony greater than 2.6

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -51,7 +51,7 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {{ render (url('sonata_admin_short_object_information', {
+                    {{ render(url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -51,12 +51,12 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% render(url('sonata_admin_short_object_information', {
+                    {{ render (url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         })
-                    )%}
+                    )}}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -55,8 +55,7 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
-                        })
-                    )}}
+                        })) }}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -51,11 +51,11 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% render url('sonata_admin_short_object_information', {
+                    {% render(url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
-                        }
+                        })
                     )%}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -55,7 +55,7 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
-                        })) }}
+                    })) }}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I'm targeting branch 3.x cause it's a bugfix.
However it's not BC compatible with all symfony2 versions.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes : No open issues.
(Do i have to open an issue to make a reference ?)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed : Change call of render function to make it compatible with Symfony greater than 3.0
Cf. https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md and Twig Bridge section
```

## Subject

<!-- Describe your Pull Request content here -->

Change from a render tag to a render function
