### PR TITLE
Replace deprecated render tag with function

### DIFF
--- a/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -24,12 +24,11 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.admin.id(sonata_admin.value) %}
-                    {% render url('sonata_admin_short_object_information', {
+                    {{ render(url('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid
-                        }
-                    )%}
+                    })) }}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I'm targeting branch 3.x cause it's a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes : No open issues.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed : Change call of render function to make it compatible with Symfony greater than 3.0
Cf. https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md and Twig Bridge section
```

## Subject

<!-- Describe your Pull Request content here -->

Change from a render tag to a render function
