### PR TITLE
Using the code from doctrine-orm-admin-bundle for the the many-to-[on…

### DIFF
--- a/Resources/views/CRUD/edit_mongo_association_script.html.twig
+++ b/Resources/views/CRUD/edit_mongo_association_script.html.twig
@@ -29,8 +29,17 @@ This code manage the many-to-[one|many] association field popup
         - if the parent has an objectId defined then the related input get updated
         - if the parent has NO object then an ajax request is made to refresh the popup
     #}
+
     var field_dialog_form_list_link_{{ id }} = function(event) {
         initialize_popup_{{ id }}();
+
+        var target = jQuery(this);
+
+        // return if the link is an anchor inside the same page
+        if (this.nodeName == 'A' && (target.attr('href').length == 0 || target.attr('href')[0] == '#')) {
+            Admin.log('[{{ id }}|field_dialog_form_list_link] element is an anchor, skipping action', this);
+            return;
+        }
 
         event.preventDefault();
         event.stopPropagation();
@@ -39,8 +48,9 @@ This code manage the many-to-[one|many] association field popup
 
         var element = jQuery(this).parents('#field_dialog_{{ id }} .sonata-ba-list-field');
 
-        // the user does click on a row column
+        // the user does not click on a row column
         if (element.length == 0) {
+            Admin.log('[{{ id }}|field_dialog_form_list_link] the user does not click on a row column, make ajax call to retrieve inner html');
             // make a recursive call (ie: reset the filter)
             jQuery.ajax({
                 type: 'GET',
@@ -49,26 +59,27 @@ This code manage the many-to-[one|many] association field popup
                 success: function(html) {
                     Admin.log('[{{ id }}|field_dialog_form_list_link] callback success, attach valid js event');
 
-                    field_dialog_{{ id }}.html(html);
+                    field_dialog_content_{{ id }}.html(html);
                     field_dialog_form_list_handle_action_{{ id }}();
+
+                    Admin.shared_setup(field_dialog_{{ id }});
                 }
             });
 
             return;
         }
 
+        Admin.log('[{{ id }}|field_dialog_form_list_link] the user select one element, update input and hide the modal');
+
         jQuery('#{{ id }}').val(element.attr('objectId'));
         jQuery('#{{ id }}').trigger('change');
 
-        field_dialog_{{ id }}.dialog('close');
-    }
+        field_dialog_{{ id }}.modal('hide');
+    };
 
     // this function handle action on the modal list when inside a selected list
     var field_dialog_form_list_handle_action_{{ id }}  =  function() {
-
         Admin.log('[{{ id }}|field_dialog_form_list_handle_action] attaching valid js event');
-
-        Admin.add_filters(field_dialog_{{ id }});
 
         // capture the submit event to make an ajax call, ie : POST data to the
         // related create admin
@@ -89,14 +100,16 @@ This code manage the many-to-[one|many] association field popup
 
                     Admin.log('[{{ id }}|field_dialog_form_list_handle_action] form submit success, restoring event');
 
-                    field_dialog_{{ id }}.html(html);
+                    field_dialog_content_{{ id }}.html(html);
                     field_dialog_form_list_handle_action_{{ id }}();
+
+                    Admin.shared_setup(field_dialog_{{ id }});
                 }
             });
         });
-    }
+    };
 
-    // handle the add link
+    // handle the list link
     var field_dialog_form_list_{{ id }} = function(event) {
 
         initialize_popup_{{ id }}();
@@ -108,7 +121,7 @@ This code manage the many-to-[one|many] association field popup
 
         var a = jQuery(this);
 
-        field_dialog_{{ id }}.html('');
+        field_dialog_content_{{ id }}.html('');
 
         // retrieve the form element from the related admin generator
         jQuery.ajax({
@@ -119,26 +132,18 @@ This code manage the many-to-[one|many] association field popup
                 Admin.log('[{{ id }}|field_dialog_form_list] retrieving the list content');
 
                 // populate the popup container
-                field_dialog_{{ id }}.html(html);
+                field_dialog_content_{{ id }}.html(html);
+
+                field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
+
+                Admin.shared_setup(field_dialog_{{ id }});
 
                 field_dialog_form_list_handle_action_{{ id }}();
 
                 // open the dialog in modal mode
-                field_dialog_{{ id }}.dialog({
-                    height: 'auto',
-                    width: 980,
-                    modal: true,
-                    resizable: true,
-                    title: '{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}',
-                    close: function(event, ui) {
-                        Admin.log('[{{ id }}|field_dialog_form_list] close callback, removing js event');
+                field_dialog_{{ id }}.modal();
 
-                        // make sure we have a clean state
-                        jQuery('a', field_dialog_{{ id }}).off('click');
-                        jQuery('form', field_dialog_{{ id }}).off('submit');
-                    },
-                    zIndex: 9998
-                });
+                Admin.setup_list_modal(field_dialog_{{ id }});
             }
         });
     };
@@ -152,7 +157,7 @@ This code manage the many-to-[one|many] association field popup
 
         var a = jQuery(this);
 
-        field_dialog_{{ id }}.html('');
+        field_dialog_content_{{ id }}.html('');
 
         Admin.log('[{{ id }}|field_dialog_form_add] add link action');
 
@@ -165,7 +170,10 @@ This code manage the many-to-[one|many] association field popup
                 Admin.log('[{{ id }}|field_dialog_form_add] ajax success', field_dialog_{{ id }});
 
                 // populate the popup container
-                field_dialog_{{ id }}.html(html);
+                field_dialog_content_{{ id }}.html(html);
+                field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
+
+                Admin.shared_setup(field_dialog_{{ id }});
 
                 // capture the submit event to make an ajax call, ie : POST data to the
                 // related create admin
@@ -173,21 +181,9 @@ This code manage the many-to-[one|many] association field popup
                 jQuery('form', field_dialog_{{ id }}).on('submit', field_dialog_form_action_{{ id }});
 
                 // open the dialog in modal mode
-                field_dialog_{{ id }}.dialog({
-                    height: 'auto',
-                    width: 850,
-                    modal: true,
-                    autoOpen: true,
-                    resizable: true,
-                    title: '{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}',
-                    close: function(event, ui) {
-                        Admin.log('[{{ id }}|field_dialog_form_add] dialog closed - removing  events');
-                        // make sure we have a clean state
-                        jQuery('a', field_dialog_{{ id }}).off('click');
-                        jQuery('form', field_dialog_{{ id }}).off('submit');
-                    },
-                    zIndex: 9998
-                });
+                field_dialog_{{ id }}.modal();
+
+                Admin.setup_list_modal(field_dialog_{{ id }});
             }
         });
     };
@@ -199,6 +195,7 @@ This code manage the many-to-[one|many] association field popup
 
         // return if the link is an anchor inside the same page
         if (this.nodeName == 'A' && (element.attr('href').length == 0 || element.attr('href')[0] == '#')) {
+            Admin.log('[{{ id }}|field_dialog_form_action] element is an anchor, skipping action', this);
             return;
         }
 
@@ -233,20 +230,18 @@ This code manage the many-to-[one|many] association field popup
 
         Admin.log('[{{ id }}|field_dialog_form_action] execute ajax call');
 
-
         // the ajax post
         jQuery(form).ajaxSubmit({
             url: url,
             type: type,
             data: data,
             success: function(data) {
-
                 Admin.log('[{{ id }}|field_dialog_form_action] ajax success');
 
                 // if the crud action return ok, then the element has been added
                 // so the widget container must be refresh with the last option available
                 if (typeof data != 'string' && data.result == 'ok') {
-                    field_dialog_{{ id }}.dialog('close');
+                    field_dialog_{{ id }}.modal('hide');
 
                     {% if sonata_admin.edit == 'list' %}
                         {#
@@ -260,7 +255,7 @@ This code manage the many-to-[one|many] association field popup
 
                         // reload the form element
                         jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
-                            url: '{{ url('sonata_admin_retrieve_form_element', {
+                            url: '{{ path('sonata_admin_retrieve_form_element', {
                                 'elementId': id,
                                 'subclass':  sonata_admin.admin.getActiveSubclassCode(),
                                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
@@ -289,27 +284,28 @@ This code manage the many-to-[one|many] association field popup
                 }
 
                 // otherwise, display form error
-                field_dialog_{{ id }}.html(data);
+                field_dialog_content_{{ id }}.html(data);
 
-                Admin.add_pretty_errors(field_dialog_{{ id }});
+                Admin.shared_setup(field_dialog_{{ id }});
 
                 // reattach the event
                 jQuery('form', field_dialog_{{ id }}).submit(field_dialog_form_action_{{ id }});
-            }, error: function(jqXHR, textStatus, errorThrown) {
-                Admin.log('[{{ id }}|field_dialog_form_action] Status: ' + textStatus);
-                Admin.log('[{{ id }}|field_dialog_form_action] Error: ' + errorThrown);
             }
         });
 
         return false;
-    }
+    };
 
-    var field_dialog_{{ id }} = false;
+    var field_dialog_{{ id }}         = false;
+    var field_dialog_content_{{ id }} = false;
+    var field_dialog_title_{{ id }}   = false;
 
     function initialize_popup_{{ id }}() {
         // initialize component
         if (!field_dialog_{{ id }}) {
-            field_dialog_{{ id }} = jQuery("#field_dialog_{{ id }}");
+            field_dialog_{{ id }}         = jQuery("#field_dialog_{{ id }}");
+            field_dialog_content_{{ id }} = jQuery(".modal-body", "#field_dialog_{{ id }}");
+            field_dialog_title_{{ id }}   = jQuery(".modal-title", "#field_dialog_{{ id }}");
 
             // move the dialog as a child of the root element, nested form breaks html ...
             jQuery(document.body).append(field_dialog_{{ id }});
@@ -339,8 +335,9 @@ This code manage the many-to-[one|many] association field popup
         return false;
     }
 
-    Admin.add_pretty_errors(field_dialog_{{ id }});
-
+    if (field_dialog_{{ id }}) {
+        Admin.shared_setup(field_dialog_{{ id }});
+    }
 
     {% if sonata_admin.edit == 'list' %}
         {#
@@ -383,6 +380,7 @@ This code manage the many-to-[one|many] association field popup
             }
 
             jQuery('#{{ id }}').val('');
+            jQuery('#{{ id }}').attr("value",'');
             jQuery('#{{ id }}').trigger('change');
 
             return false;
@@ -394,15 +392,16 @@ This code manage the many-to-[one|many] association field popup
         // update the label
         jQuery('#{{ id }}').on('change', function(event) {
 
-            Admin.log('[{{ id }}] update the label');
+            Admin.log('[{{ id }}|on:change] update the label');
 
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
             jQuery.ajax({
                 type: 'GET',
-                url: '{{ url('sonata_admin_short_object_information', {
+                url: '{{ path('sonata_admin_short_object_information', {
                     'objectId': 'OBJECT_ID',
                     'uniqid': associationadmin.uniqid,
-                    'code': associationadmin.code
+                    'code': associationadmin.code,
+                    'linkParameters': sonata_admin.field_description.options.link_parameters
                 })}}'.replace('OBJECT_ID', jQuery(this).val()),
                 dataType: 'html',
                 success: function(html) {

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -105,8 +105,17 @@ file that was distributed with this source code.
             {{ form_widget(form) }}
         </span>
 
-        <div class="container sonata-ba-modal sonata-ba-modal-edit-one-to-one" style="display: none" id="field_dialog_{{ id }}">
-
+        <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title"></h4>
+                    </div>
+                    <div class="modal-body">
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->

I am targetting this branch, because this is a BC bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Fixed
- Filter functionality in the the many-to-[one|many] association field popup now doesn't load the parent url
- Delete Button for the many-to-[one|many] association field works now as intended
```
## Subject

This is mostly the same as #140 .
It fixes the many-to-[one|many] association field popup using the code from doctrine-orm-admin-bundle.
Additionally i fixed the delete button.
