### PR TITLE
use createMock() instead of deprecated getMock()

### DIFF
--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -137,7 +137,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testGetParent()
     {
-        $adminMock = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $field = new FieldDescription();
         $field->setParent($adminMock);
 
@@ -154,7 +154,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testGetAdmin()
     {
-        $adminMock = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $field = new FieldDescription();
         $field->setAdmin($adminMock);
 
@@ -163,9 +163,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testGetAssociationAdmin()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\Admin')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
@@ -178,9 +176,7 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testHasAssociationAdmin()
     {
-        $adminMock = $this->getMockBuilder('Sonata\AdminBundle\Admin\Admin')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $adminMock = $this->createMock('Sonata\AdminBundle\Admin\Admin');
         $adminMock->expects($this->once())
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf('Sonata\AdminBundle\Admin\FieldDescriptionInterface'));
@@ -196,7 +192,9 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 
     public function testGetValue()
     {
-        $mockedObject = $this->getMock('MockedTestObject', array('myMethod'));
+        $mockedObject = $this->getMockBuilder('MockedTestObject')
+            ->setMethods(array('myMethod'))
+            ->getMock();
         $mockedObject->expects($this->once())
             ->method('myMethod')
             ->will($this->returnValue('myMethodValue'));
@@ -212,7 +210,9 @@ class FieldDescriptionTest extends PHPUnit_Framework_TestCase
      */
     public function testGetValueWhenCannotRetrieve()
     {
-        $mockedObject = $this->getMock('MockedTestObject', array('myMethod'));
+        $mockedObject = $this->getMockBuilder('MockedTestObject')
+            ->setMethods(array('myMethod'))
+            ->getMock();
         $mockedObject->expects($this->never())
             ->method('myMethod')
             ->will($this->returnValue('myMethodValue'));

--- a/Tests/Admin/FieldDescriptionTest.php
+++ b/Tests/Admin/FieldDescriptionTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Admin;
 
 use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class FieldDescriptionTest extends \PHPUnit_Framework_TestCase
+class FieldDescriptionTest extends PHPUnit_Framework_TestCase
 {
     public function testOptions()
     {

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -46,12 +46,12 @@ class FormContractorTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultOptionsForSonataFormTypes()
     {
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $modelManager = $this->getMock('Sonata\AdminBundle\Model\ModelManagerInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $modelManager = $this->createMock('Sonata\AdminBundle\Model\ModelManagerInterface');
         $modelClass = 'FooEntity';
         $admin->method('getModelManager')->willReturn($modelManager);
         $admin->method('getClass')->willReturn($modelClass);
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->method('getAdmin')->willReturn($admin);
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
@@ -73,11 +73,7 @@ class FormContractorTest extends PHPUnit_Framework_TestCase
                     // add class type.
                     $classType,
                     // add instance of class type.
-                    get_class(
-                        $this->getMockBuilder($classType)
-                            ->disableOriginalConstructor()
-                            ->getMock()
-                    )
+                    get_class($this->createMock($classType))
                 );
             }
             $adminTypes[] = 'Sonata\AdminBundle\Form\Type\AdminType';
@@ -112,13 +108,11 @@ class FormContractorTest extends PHPUnit_Framework_TestCase
     public function testAdminClassAttachForNotMappedField()
     {
         // Given
-        $modelManager = $this->getMockBuilder('Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $modelManager = $this->createMock('Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager');
         $modelManager->method('hasMetadata')->willReturn(false);
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->method('getModelManager')->willReturn($modelManager);
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->method('getMappingType')->willReturn('one');
         $fieldDescription->method('getType')->willReturn('sonata_type_model_list');
         $fieldDescription->method('getOption')->with($this->logicalOr(

--- a/Tests/Builder/FormContractorTest.php
+++ b/Tests/Builder/FormContractorTest.php
@@ -13,9 +13,10 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
 
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Form\FormFactoryInterface;
 
-class FormContractorTest extends \PHPUnit_Framework_TestCase
+class FormContractorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var FormFactoryInterface|\PHPUnit_Framework_MockObject_MockObject

--- a/Tests/Filter/FilterWithQueryBuilderTest.php
+++ b/Tests/Filter/FilterWithQueryBuilderTest.php
@@ -11,7 +11,9 @@
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 
-abstract class FilterWithQueryBuilderTest extends \PHPUnit_Framework_TestCase
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+abstract class FilterWithQueryBuilderTest extends PHPUnit_Framework_TestCase
 {
     private $queryBuilder = null;
     private $expr = null;

--- a/Tests/Filter/FilterWithQueryBuilderTest.php
+++ b/Tests/Filter/FilterWithQueryBuilderTest.php
@@ -20,17 +20,13 @@ abstract class FilterWithQueryBuilderTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->queryBuilder = $this->getMockBuilder('Doctrine\ODM\MongoDB\Query\Builder')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $this->queryBuilder = $this->createMock('Doctrine\ODM\MongoDB\Query\Builder');
         $this->queryBuilder
                 ->expects($this->any())
                 ->method('field')
                 ->will($this->returnSelf())
         ;
-        $this->expr = $this->getMockBuilder('Doctrine\ODM\MongoDB\Query\Expr')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->expr = $this->createMock('Doctrine\ODM\MongoDB\Query\Expr');
         $this->expr
             ->expects($this->any())
             ->method('field')

--- a/Tests/Filter/ModelFilterTest.php
+++ b/Tests/Filter/ModelFilterTest.php
@@ -33,7 +33,7 @@ class ModelFilterTest extends FilterWithQueryBuilderTest
      */
     public function getFieldDescription(array $options)
     {
-        $fieldDescription = $this->getMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
+        $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
         $fieldDescription->expects($this->once())->method('getOptions')->will($this->returnValue($options));
         $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('field_name'));
 

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning()
+            ->getMock();
+    }
+}

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Model;
 
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class ModelManagerTest extends \PHPUnit_Framework_TestCase
+class ModelManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {

--- a/Tests/Model/ModelManagerTest.php
+++ b/Tests/Model/ModelManagerTest.php
@@ -18,9 +18,7 @@ class ModelManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testFilterEmpty()
     {
-        $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\ManagerRegistry')
-                ->disableOriginalConstructor()
-                ->getMock();
+        $registry = $this->createMock('Symfony\Bridge\Doctrine\ManagerRegistry');
 
         $manager = new ModelManager($registry);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.
