### PR TITLE
Build actions field description based on provided type too

### DIFF
--- a/Builder/ListBuilder.php
+++ b/Builder/ListBuilder.php
@@ -73,7 +73,7 @@ class ListBuilder implements ListBuilderInterface
      */
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
-        if ($fieldDescription->getName() == '_action') {
+        if ($fieldDescription->getName() === '_action' || $fieldDescription->getType() === 'actions') {
             $this->buildActionFieldDescription($fieldDescription);
         }
 
@@ -147,7 +147,7 @@ class ListBuilder implements ListBuilderInterface
         }
 
         if (null === $fieldDescription->getType()) {
-            $fieldDescription->setType('action');
+            $fieldDescription->setType('actions');
         }
 
         if (null === $fieldDescription->getOption('name')) {

--- a/Tests/Builder/ListBuilderTest.php
+++ b/Tests/Builder/ListBuilderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineORMAdminBundle\Tests\Builder;
+
+use Prophecy\Argument;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineMongoDBAdminBundle\Builder\ListBuilder;
+use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+/**
+ * @author Andrew Mor-Yaroslavtsev <andrejs@gmail.com>
+ */
+class ListBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TypeGuesserInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    protected $typeGuesser;
+
+    /**
+     * @var ListBuilder
+     */
+    protected $listBuilder;
+
+    /**
+     * @var AdminInterface|\Prophecy\Prophecy\ObjectProphecy
+     */
+    protected $admin;
+
+    /**
+     * @var ModelManager|\Prophecy\Prophecy\ObjectProphecy
+     */
+    protected $modelManager;
+
+    protected function setUp()
+    {
+        $this->typeGuesser = $this->prophesize('Sonata\AdminBundle\Guesser\TypeGuesserInterface');
+
+        $this->modelManager = $this->prophesize('Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager');
+        $this->modelManager->hasMetadata(Argument::any())->willReturn(false);
+
+        $this->admin = $this->prophesize('Sonata\AdminBundle\Admin\AbstractAdmin');
+        $this->admin->getClass()->willReturn('Foo');
+        $this->admin->getModelManager()->willReturn($this->modelManager);
+        $this->admin->addListFieldDescription(Argument::any(), Argument::any())
+            ->willReturn();
+
+        $this->listBuilder = new ListBuilder($this->typeGuesser->reveal());
+    }
+
+    public function testAddListActionField()
+    {
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('foo');
+        $list = $this->listBuilder->getBaseList();
+        $this->listBuilder
+            ->addField($list, 'actions', $fieldDescription, $this->admin->reveal());
+
+        $this->assertSame(
+            'SonataAdminBundle:CRUD:list__action.html.twig',
+            $list->get('foo')->getTemplate(),
+            'Custom list action field has a default list action template assigned'
+        );
+    }
+
+    public function testCorrectFixedActionsFieldType()
+    {
+        $this->typeGuesser->guessType(
+            Argument::any(), Argument::any(), Argument::any()
+        )->willReturn(
+            new TypeGuess(null, array(), Guess::LOW_CONFIDENCE)
+        );
+
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('_action');
+        $list = $this->listBuilder->getBaseList();
+        $this->listBuilder->addField($list, null, $fieldDescription, $this->admin->reveal());
+
+        $this->assertSame(
+            'actions',
+            $list->get('_action')->getType(),
+            'Standard list _action field has "actions" type'
+        );
+    }
+}
+

--- a/Tests/Builder/ListBuilderTest.php
+++ b/Tests/Builder/ListBuilderTest.php
@@ -96,4 +96,3 @@ class ListBuilderTest extends \PHPUnit_Framework_TestCase
         );
     }
 }
-


### PR DESCRIPTION
I am targeting this branch, because it's a patch.

References sonata-project/SonataDoctrineORMAdminBundle#672.

## Changelog

```markdown
### Fixed
- A list field with `actions` type will get all the required field options just like the `_action` field.
- `_action` field will get a proper `actions` type.
```
## Subject

`ListBuilder` fix, mirrors SonataDoctrineORMAdmin change.