### PR TITLE
Support sorting by embedded document fields

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -65,7 +65,13 @@ class ProxyQuery implements ProxyQueryInterface
 
     public function setSortBy($parentAssociationMappings, $fieldMapping)
     {
-        $this->sortBy = $fieldMapping['fieldName'];
+        $parents = '';
+        if (isset($parentAssociationMappings)) {
+            foreach ($parentAssociationMappings as $mapping) {
+                $parents .= $mapping['fieldName'].'.';
+            }
+        }
+        $this->sortBy = $parents.$fieldMapping['fieldName'];
     }
 
     public function getSortBy()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it's a fix for an existing feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Support sorting by embedded document fields 
```

## Subject

When your Datagrid contains a field of an embedded document, you weren't able to sort by its column. That's caused by the $parentAssociationMappings paremeter of setSortBy being ignored. The fix applies the parents document names dot separated in front of the field name. The fix should only target the niche "embedded documents" case.
