### PR TITLE
Maintain File input state when adding to collections

### DIFF
--- a/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
@@ -47,7 +47,7 @@ This code manage the one-to-many association field popup
                     return;
                 }
                 
-                var $newForm = jQuery(jQuery.parseHTML(html));
+                var $newForm = jQuery(html);
                 var $oldForm = jQuery('#field_container_{{ id }}');
 
                 // Maintain state of file inputs

--- a/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
+++ b/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
@@ -46,8 +46,17 @@ This code manage the one-to-many association field popup
                 if (!html.length) {
                     return;
                 }
+                
+                var $newForm = jQuery(jQuery.parseHTML(html));
+                var $oldForm = jQuery('#field_container_{{ id }}');
 
-                jQuery('#field_container_{{ id }}').replaceWith(html); // replace the html
+                // Maintain state of file inputs
+                $oldForm.find('input[type="file"]').each(function(){
+                    var id = '#'$(this).attr('id');
+                    $newForm.find(id).replaceWith($(this));
+                });
+
+                $oldForm.replaceWith($newForm);  // replace the html
                 if(jQuery('input[type="file"]', form).length > 0) {
                     jQuery(form).attr('enctype', 'multipart/form-data');
                     jQuery(form).attr('encoding', 'multipart/form-data');


### PR DESCRIPTION
I am targeting this branch, because it is a BC bug fix .

Fixes sonata-project/SonataAdminBundle#4227 for MongoDB
Replicating https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/720

## Changelog
```markdown

### Fixed
- Patched collection form handling script to maintain File input state when new items are added to collections

```

## Subject
When adding items to collection, full form is returned and re-rendered. This update copies over the file input state into the newly fetched form.
