### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "jmikola/geojson": "^1.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of Symfony.
```
