### PR TITLE
Add support for FQCN form type

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactory;
 
 class DatagridBuilder implements DatagridBuilderInterface
@@ -140,7 +141,7 @@ class DatagridBuilder implements DatagridBuilderInterface
             $defaultOptions['csrf_protection'] = false;
         }
 
-        $formBuilder = $this->formFactory->createNamedBuilder('filter', 'form', [], $defaultOptions);
+        $formBuilder = $this->formFactory->createNamedBuilder('filter', FormType::class, [], $defaultOptions);
 
         return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
     }

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -15,6 +15,7 @@ use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
 
 class FormContractor implements FormContractorInterface
@@ -78,7 +79,7 @@ class FormContractor implements FormContractorInterface
      */
     public function getFormBuilder($name, array $options = [])
     {
-        return $this->getFormFactory()->createNamedBuilder($name, 'form', null, $options);
+        return $this->getFormFactory()->createNamedBuilder($name, FormType::class, null, $options);
     }
 
     /**
@@ -98,7 +99,10 @@ class FormContractor implements FormContractorInterface
             'Sonata\AdminBundle\Form\Type\ModelListType',
         ])) {
             if ('list' == $fieldDescription->getOption('edit')) {
-                throw new \LogicException('The ``sonata_type_model`` type does not accept an ``edit`` option anymore, please review the UPGRADE-2.1.md file from the SonataAdminBundle');
+                throw new \LogicException(
+                    'The ``Sonata\AdminBundle\Form\Type\ModelType`` type does not accept an ``edit`` option anymore,'
+                    .' please review the UPGRADE-2.1.md file from the SonataAdminBundle'
+                );
             }
 
             $options['class'] = $fieldDescription->getTargetEntity();
@@ -106,7 +110,12 @@ class FormContractor implements FormContractorInterface
             // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
         } elseif ($this->checkFormType($type, ['sonata_type_admin']) || $this->checkFormClass($type, ['Sonata\AdminBundle\Form\Type\AdminType'])) {
             if (!$fieldDescription->getAssociationAdmin()) {
-                throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
+                throw new \RuntimeException(sprintf(
+                    'The current field `%s` is not linked to an admin.'
+                    .' Please create one for the target entity : `%s`',
+                    $fieldDescription->getName(),
+                    $fieldDescription->getTargetEntity()
+                ));
             }
 
             $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
@@ -114,7 +123,12 @@ class FormContractor implements FormContractorInterface
             // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony <2.8
         } elseif ($this->checkFormType($type, ['sonata_type_collection']) || $this->checkFormClass($type, ['Sonata\CoreBundle\Form\Type\CollectionType'])) {
             if (!$fieldDescription->getAssociationAdmin()) {
-                throw new \RuntimeException(sprintf('The current field `%s` is not linked to an admin. Please create one for the target entity : `%s`', $fieldDescription->getName(), $fieldDescription->getTargetEntity()));
+                throw new \RuntimeException(sprintf(
+                    'The current field `%s` is not linked to an admin.'
+                    .' Please create one for the target entity : `%s`',
+                    $fieldDescription->getName(),
+                    $fieldDescription->getTargetEntity()
+                ));
             }
 
             // NEXT_MAJOR: Use only FQCN when dropping support for Symfony <2.8

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -12,6 +12,9 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
 
 abstract class AbstractDateFilter extends Filter
@@ -89,20 +92,20 @@ abstract class AbstractDateFilter extends Filter
      */
     public function getRenderSettings()
     {
-        $name = 'sonata_type_filter_date';
+        $name = DateType::class;
 
-        if ($this->time) {
-            $name .= 'time';
-        }
-
-        if ($this->range) {
-            $name .= '_range';
+        if ($this->time && $this->range) {
+            $name = DateTimeRangeType::class;
+        } elseif ($this->time) {
+            $name = DateTimeType::class;
+        } elseif ($this->range) {
+            $name = DateRangeType::class;
         }
 
         return [$name, [
-                'field_type' => $this->getFieldType(),
-                'field_options' => $this->getFieldOptions(),
-                'label' => $this->getLabel(),
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'label' => $this->getLabel(),
         ]];
     }
 

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -12,7 +12,9 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class BooleanFilter extends Filter
 {
@@ -66,10 +68,10 @@ class BooleanFilter extends Filter
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => 'hidden',
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
             'label' => $this->getLabel(),
         ]];

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -12,6 +12,9 @@
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CallbackFilter extends Filter
 {
@@ -53,15 +56,15 @@ class CallbackFilter extends Filter
             'active_callback' => function ($data) {
                 return isset($data['value']) && $data['value'];
             },
-            'field_type' => 'text',
-            'operator_type' => 'hidden',
+            'field_type' => TextType::class,
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
         ];
     }
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
                 'field_type' => $this->getFieldType(),
                 'field_options' => $this->getFieldOptions(),
                 'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 
 class ChoiceFilter extends Filter
 {
@@ -69,7 +70,7 @@ class ChoiceFilter extends Filter
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
                 'operator_type' => 'sonata_type_boolean',
                 'field_type' => $this->getFieldType(),
                 'field_options' => $this->getFieldOptions(),

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -11,8 +11,10 @@
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
+use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\Common\Collections\Collection;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\CoreBundle\Form\Type\EqualType;
 
 class ModelFilter extends Filter
@@ -47,16 +49,16 @@ class ModelFilter extends Filter
         return [
             'mapping_type' => false,
             'field_name' => false,
-            'field_type' => 'document',
+            'field_type' => DocumentType::class,
             'field_options' => [],
-            'operator_type' => 'sonata_type_equal',
+            'operator_type' => EqualType::class,
             'operator_options' => [],
         ];
     }
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -50,7 +50,7 @@ class NumberFilter extends Filter
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_number', [
+        return [NumberType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -66,10 +66,10 @@ class StringFilter extends Filter
 
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_choice', [
-                'field_type' => $this->getFieldType(),
-                'field_options' => $this->getFieldOptions(),
-                'label' => $this->getLabel(),
+        return [ChoiceType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'label' => $this->getLabel(),
         ]];
     }
 }

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -11,9 +11,14 @@
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Guesser;
 
+use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineMongoDBAdminBundle\Model\MissingPropertyMetadataException;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -47,10 +52,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                     //case ClassMetadataInfo::MANY_TO_ONE:
                     //case ClassMetadataInfo::MANY_TO_MANY:
 
-                    $options['operator_type'] = 'sonata_type_equal';
+                    $options['operator_type'] = EqualType::class;
                     $options['operator_options'] = [];
 
-                    $options['field_type'] = 'document';
+                    $options['field_type'] = DocumentType::class;
                     $options['field_options'] = [
                         'class' => $mapping['targetDocument'],
                     ];
@@ -70,7 +75,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
 
         switch ($metadata->getTypeOfField($propertyName)) {
             case 'boolean':
-                $options['field_type'] = 'sonata_type_boolean';
+                $options['field_type'] = BooleanType::class;
                 $options['field_options'] = [];
 
                 return new TypeGuess('doctrine_mongo_boolean', $options, Guess::HIGH_CONFIDENCE);
@@ -86,13 +91,13 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             case 'int':
             case 'bigint':
             case 'smallint':
-                $options['field_type'] = 'number';
+                $options['field_type'] = NumberType::class;
 
                 return new TypeGuess('doctrine_mongo_number', $options, Guess::MEDIUM_CONFIDENCE);
             case 'id':
             case 'string':
             case 'text':
-                $options['field_type'] = 'text';
+                $options['field_type'] = TextType::class;
 
                 return new TypeGuess('doctrine_mongo_string', $options, Guess::MEDIUM_CONFIDENCE);
             case 'time':

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -55,6 +55,7 @@ class FormContractorTest extends TestCase
         $fieldDescription->method('getAdmin')->willReturn($admin);
         $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+
         $modelTypes = [
             'sonata_type_model',
             'sonata_type_model_list',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

I guess, it closes #219 and https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/178.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add support for FQCNs form types
```
## Subject

<!-- Describe your Pull Request content here -->
There are still some classes not supporting form types FQCNs, so you can't disable [form mapping](https://github.com/sonata-project/SonataCoreBundle/commit/7c72ed83ebd773837e0cc06d56cea9eb4b2e6283). It is based on https://github.com/sonata-project/SonataDoctrineORMAdminBundle.