### PR TITLE
Avoid Type error: trim() expects parameter 1 to be string, null given

### DIFF
--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -26,7 +26,7 @@ class StringFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $name, $field, $data): void
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+        if (!$data || !is_array($data) || !array_key_exists('value', $data) || empty($data['value'])) {
             return;
         }
 


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Avoid Type error: trim() expects parameter 1 to be string, null given
```

## Subject

After upgrading I experienced:
`Type error: trim() expects parameter 1 to be string, null given`
`FatalThrowableError
in vendor/sonata-project/doctrine-mongodb-admin-bundle/src/Filter/StringFilter.php (line 33)`
Tracing down it seems our db has some null values which lead the admin to not show the listing page
As far as I can see the code already checks for empty values, but after trimming, so trim on null is now prevented by additional empty check
