### PR TITLE
Fix wrong property name on FormContractor

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -20,6 +20,11 @@ use Symfony\Component\Form\FormFactoryInterface;
 
 class FormContractor implements FormContractorInterface
 {
+    /**
+     * @deprecated since version 3.x, to be removed in 4.0
+     *
+     * @var FormFactoryInterface
+     */
     protected $fieldFactory;
 
     /**


### PR DESCRIPTION
Duplicates https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/172

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Fix wrong property name on `FormContractor`
```

## Subject

The other is never used. As a protected one, I keep it for BC.
Because of the deprecation, this should be delivered as a new minor.
