### PR TITLE
Check for filter Value in StringFilter

### DIFF
--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -24,7 +24,7 @@ class StringFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $name, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+        if (!$data || !is_array($data) || !array_key_exists('value', $data) || null == $data['value']) {
             return;
         }
 


### PR DESCRIPTION
otherwise  trim($data['value']);  results in a Type error: trim() expects parameter 1 to be string, null given error message

Solves Issue #268
