### PR TITLE
Fix typo in template

### DIFF
--- a/src/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
@@ -52,11 +52,14 @@ This code manage the one-to-many association field popup
 
                 // Maintain state of file inputs
                 $oldForm.find('input[type="file"]').each(function(){
-                    var id = '#'$(this).attr('id');
+                    var id = '#' + $(this).attr('id');
                     $newForm.find(id).replaceWith($(this));
                 });
 
                 $oldForm.replaceWith($newForm);  // replace the html
+                
+                Admin.shared_setup(jQuery('#field_container_{{ id }}'));
+                    
                 if(jQuery('input[type="file"]', form).length > 0) {
                     jQuery(form).attr('enctype', 'multipart/form-data');
                     jQuery(form).attr('encoding', 'multipart/form-data');


### PR DESCRIPTION
I am targeting this branch, because it does not work.

Closes #226  #256

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Typo in javascript in `edit_mongo_one_association_script.html.twig`

```

  
  
  
  