### PR TITLE
Update deprecated twig paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "symfony/dependency-injection": "^2.8 || ^3.2 || ^4.0",
         "symfony/doctrine-bridge": "^2.8 || ^3.2 || ^4.0",
         "symfony/form": "^2.8 || ^3.2 || ^4.0",
-        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0"
+        "symfony/http-kernel": "^2.8 || ^3.2 || ^4.0",
+        "twig/extensions": "^1.0",
+        "twig/twig": "^1.34 || ^2.0"
     },
     "require-dev": {
         "jmikola/geojson": "^1.0",

--- a/src/Resources/views/CRUD/edit_mongo_collection.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_collection.html.twig
@@ -132,7 +132,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {# include association code #}
-            {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_one_association_script.html.twig' %}
+            {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_one_association_script.html.twig' %}
 
         {% else %}
             <span id="field_actions_{{ id }}" >
@@ -153,7 +153,7 @@ file that was distributed with this source code.
 
             </div>
 
-            {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_association_script.html.twig' %}
+            {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_association_script.html.twig' %}
         {% endif %}
     </div>
 {% endif %}

--- a/src/Resources/views/CRUD/edit_mongo_many.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_many.html.twig
@@ -33,5 +33,5 @@ file that was distributed with this source code.
         </div>
     </div>
 
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_association_script.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_association_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -90,5 +90,5 @@ file that was distributed with this source code.
         </div>
     </div>
 
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_association_script.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_association_script.html.twig' %}
 {% endif %}

--- a/src/Resources/views/CRUD/show_mongo_many.html.twig
+++ b/src/Resources/views/CRUD/show_mongo_many.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_show_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field%}
     <ul class="sonata-ba-show-many-to-many">

--- a/src/Resources/views/Form/filter_admin_fields.html.twig
+++ b/src/Resources/views/Form/filter_admin_fields.html.twig
@@ -9,4 +9,4 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:Form:filter_admin_fields.html.twig' %}
+{% extends '@SonataAdmin/Form/filter_admin_fields.html.twig' %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -10,20 +10,20 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:Form:form_admin_fields.html.twig' %}
+{% extends '@SonataAdmin/Form/form_admin_fields.html.twig' %}
 
 
 {# Custom Sonata Admin Extension #}
 {% block sonata_admin_mongo_one_widget %}
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_one.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_one.html.twig' %}
 {% endblock %}
 
 {% block sonata_admin_mongo_many_widget %}
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_many.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_many.html.twig' %}
 {% endblock %}
 
 {% block sonata_admin_mongo_collection %}
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_collection.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_collection.html.twig' %}
 {% endblock %}
 
 {% block sonata_type_model_widget %}
@@ -110,7 +110,7 @@ file that was distributed with this source code.
         </div>
     </div>
 
-    {% include 'SonataDoctrineMongoDBAdminBundle:CRUD:edit_mongo_association_script.html.twig' %}
+    {% include '@SonataDoctrineMongoDBAdmin/CRUD/edit_mongo_association_script.html.twig' %}
 {% endblock %}
 
 {% block sonata_type_admin_widget %}


### PR DESCRIPTION
I am targeting this branch, because why not.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added twig dependency

### Changed
- Replace twig paths with new naming conventions
```

## Subject

<!-- Describe your Pull Request content here -->

Colon separators in twig paths is no longer recommended https://symfony.com/doc/3.3/templating/namespaced_paths.html 
  