### PR TITLE
Updating link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ master | [![Build Status][travis_unstable_badge]][travis_unstable_link] | [![Cov
 
 ## Documentation
 
-Check out the documentation on the [official website](https://sonata-project.org/bundles/doctrine-mongodb-admin).
+Check out the documentation on the [official website](https://sonata-project.org/bundles/mongo-admin).
 
 ## Support
 


### PR DESCRIPTION
I am targeting this branch, because bug.

Closes #284

## Subject

Updated link for documentation in README
