### PR TITLE
Fixes missing association admin class in datagrid filters.

### DIFF
--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -28,7 +28,7 @@ class FieldDescription extends BaseFieldDescription
      */
     public function setAssociationMapping($associationMapping)
     {
-        if (!is_array($associationMapping)) {
+        if (!\is_array($associationMapping)) {
             throw new \RuntimeException('The association mapping must be an array');
         }
 
@@ -54,7 +54,7 @@ class FieldDescription extends BaseFieldDescription
      */
     public function setFieldMapping($fieldMapping)
     {
-        if (!is_array($fieldMapping)) {
+        if (!\is_array($fieldMapping)) {
             throw new \RuntimeException('The field mapping must be an array');
         }
 
@@ -71,7 +71,7 @@ class FieldDescription extends BaseFieldDescription
     public function setParentAssociationMappings(array $parentAssociationMappings)
     {
         foreach ($parentAssociationMappings as $parentAssociationMapping) {
-            if (!is_array($parentAssociationMapping)) {
+            if (!\is_array($parentAssociationMapping)) {
                 throw new \RuntimeException('An association mapping must be an array');
             }
         }

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -68,7 +68,7 @@ class DatagridBuilder implements DatagridBuilderInterface
             if (isset($metadata->fieldMappings[$lastPropertyName])) {
                 $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$lastPropertyName]));
 
-                if ($metadata->fieldMappings[$lastPropertyName]['type'] == 'string') {
+                if ('string' == $metadata->fieldMappings[$lastPropertyName]['type']) {
                     $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
                 }
             }
@@ -84,7 +84,7 @@ class DatagridBuilder implements DatagridBuilderInterface
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY])) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }
@@ -107,7 +107,7 @@ class DatagridBuilder implements DatagridBuilderInterface
             $options = $guessType->getOptions();
 
             foreach ($options as $name => $value) {
-                if (is_array($value)) {
+                if (\is_array($value)) {
                     $fieldDescription->setOption($name, array_merge($value, $fieldDescription->getOption($name, [])));
                 } else {
                     $fieldDescription->setOption($name, $fieldDescription->getOption($name, $value));

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Builder;
 
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\DatagridBuilderInterface;
@@ -82,6 +83,10 @@ class DatagridBuilder implements DatagridBuilderInterface
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
+
+        if (in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY])) {
+            $admin->attachAdminClass($fieldDescription);
+        }
     }
 
     /**

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -64,14 +64,14 @@ class FormContractor implements FormContractorInterface
             throw new \RuntimeException(sprintf(
                 'Please define a type for field `%s` in `%s`',
                 $fieldDescription->getName(),
-                get_class($admin)
+                \get_class($admin)
             ));
         }
 
         $fieldDescription->setAdmin($admin);
         $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'standard'));
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }
@@ -95,7 +95,7 @@ class FormContractor implements FormContractorInterface
         $options['sonata_field_description'] = $fieldDescription;
 
         // NEXT_MAJOR: Check only against FQCNs when dropping support for Symfony 2.8
-        if (in_array($type, [
+        if (\in_array($type, [
             'sonata_type_model',
             'sonata_type_model_list',
             'sonata_type_model_hidden',
@@ -139,7 +139,7 @@ class FormContractor implements FormContractorInterface
                 ));
             }
 
-            if (!in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
+            if (!\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
                 throw new \RuntimeException(sprintf(
                     'You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One.'
                     .' Maybe you want `sonata_type_collection` instead?',

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -102,7 +102,7 @@ class ListBuilder implements ListBuilderInterface
         }
 
         if (!$fieldDescription->getType()) {
-            throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), get_class($admin)));
+            throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
@@ -130,7 +130,7 @@ class ListBuilder implements ListBuilderInterface
             $fieldDescription->setTemplate($template);
         }
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -93,7 +93,7 @@ class ShowBuilder implements ShowBuilderInterface
         }
 
         if (!$fieldDescription->getType()) {
-            throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), get_class($admin)));
+            throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
@@ -121,7 +121,7 @@ class ShowBuilder implements ShowBuilderInterface
             $fieldDescription->setTemplate($template);
         }
 
-        if (in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY])) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -30,7 +30,7 @@ class Pager extends BasePager
     {
         $countQuery = clone $this->getQuery();
 
-        if (count($this->getParameters()) > 0) {
+        if (\count($this->getParameters()) > 0) {
             $countQuery->setParameters($this->getParameters());
         }
 
@@ -65,7 +65,7 @@ class Pager extends BasePager
         $this->getQuery()->setFirstResult(0);
         $this->getQuery()->setMaxResults(0);
 
-        if (count($this->getParameters()) > 0) {
+        if (\count($this->getParameters()) > 0) {
             $this->getQuery()->setParameters($this->getParameters());
         }
 

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -35,7 +35,7 @@ class ProxyQuery implements ProxyQueryInterface
 
     public function __call($name, $args)
     {
-        return call_user_func_array([$this->queryBuilder, $name], $args);
+        return \call_user_func_array([$this->queryBuilder, $name], $args);
     }
 
     public function __clone()

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -25,7 +25,7 @@ class AddTemplatesCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
-            if (!isset($attributes[0]['manager_type']) || $attributes[0]['manager_type'] != 'doctrine_mongodb') {
+            if (!isset($attributes[0]['manager_type']) || 'doctrine_mongodb' != $attributes[0]['manager_type']) {
                 continue;
             }
 

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -39,7 +39,7 @@ abstract class AbstractDateFilter extends Filter
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
         //check data sanity
-        if (true !== is_array($data)) {
+        if (true !== \is_array($data)) {
             return;
         }
 
@@ -130,7 +130,7 @@ abstract class AbstractDateFilter extends Filter
      */
     protected function typeRequiresValue($type)
     {
-        return in_array($type, [
+        return \in_array($type, [
             DateType::TYPE_NULL,
             DateType::TYPE_NOT_NULL,
         ]);

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -26,28 +26,28 @@ class BooleanFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
             return;
         }
 
-        if (is_array($data['value'])) {
+        if (\is_array($data['value'])) {
             $values = [];
             foreach ($data['value'] as $v) {
-                if (!in_array($v, [BooleanType::TYPE_NO, BooleanType::TYPE_YES])) {
+                if (!\in_array($v, [BooleanType::TYPE_NO, BooleanType::TYPE_YES])) {
                     continue;
                 }
 
                 $values[] = (BooleanType::TYPE_YES == $v) ? true : false;
             }
 
-            if (0 == count($values)) {
+            if (0 == \count($values)) {
                 return;
             }
 
             $queryBuilder->field($field)->in($values);
             $this->active = true;
         } else {
-            if (!in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES])) {
+            if (!\in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES])) {
                 return;
             }
 

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -28,17 +28,17 @@ class CallbackFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!is_callable($this->getOption('callback'))) {
+        if (!\is_callable($this->getOption('callback'))) {
             throw new \RuntimeException(sprintf(
                 'Please provide a valid callback option "filter" for field "%s"',
                 $this->getName()
             ));
         }
 
-        call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
+        \call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $data);
 
-        if (is_callable($this->getOption('active_callback'))) {
-            $this->active = call_user_func($this->getOption('active_callback'), $data);
+        if (\is_callable($this->getOption('active_callback'))) {
+            $this->active = \call_user_func($this->getOption('active_callback'), $data);
 
             return;
         }

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -26,16 +26,16 @@ class ChoiceFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
             return;
         }
 
-        if (is_array($data['value'])) {
-            if (0 == count($data['value'])) {
+        if (\is_array($data['value'])) {
+            if (0 == \count($data['value'])) {
                 return;
             }
 
-            if (in_array('all', $data['value'])) {
+            if (\in_array('all', $data['value'])) {
                 return;
             }
 

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -27,7 +27,7 @@ class ModelFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !array_key_exists('value', $data)) {
             return;
         }
 
@@ -37,7 +37,7 @@ class ModelFilter extends Filter
 
         $field = $this->getIdentifierField($field);
 
-        if (is_array($data['value'])) {
+        if (\is_array($data['value'])) {
             $this->handleMultiple($queryBuilder, $alias, $field, $data);
         } else {
             $this->handleScalar($queryBuilder, $alias, $field, $data);
@@ -77,7 +77,7 @@ class ModelFilter extends Filter
      */
     protected function handleMultiple(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (0 == count($data['value'])) {
+        if (0 == \count($data['value'])) {
             return;
         }
 

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -24,7 +24,7 @@ class NumberFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data) || !is_numeric($data['value'])) {
+        if (!$data || !\is_array($data) || !array_key_exists('value', $data) || !is_numeric($data['value'])) {
             return;
         }
 

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -24,13 +24,13 @@ class StringFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $name, $field, $data)
     {
-        if (!$data || !is_array($data) || !array_key_exists('value', $data) || null == $data['value']) {
+        if (!$data || !\is_array($data) || !array_key_exists('value', $data) || null == $data['value']) {
             return;
         }
 
         $data['value'] = trim($data['value']);
 
-        if (0 == strlen($data['value'])) {
+        if (0 == \strlen($data['value'])) {
             return;
         }
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -86,7 +86,7 @@ class ModelManager implements ModelManagerInterface
      */
     public function getNewFieldDescriptionInstance($class, $name, array $options = [])
     {
-        if (!is_string($name)) {
+        if (!\is_string($name)) {
             throw new \RunTimeException('The name argument must be a string');
         }
 
@@ -194,8 +194,8 @@ class ModelManager implements ModelManagerInterface
      */
     public function getDocumentManager($class)
     {
-        if (is_object($class)) {
-            $class = get_class($class);
+        if (\is_object($class)) {
+            $class = \get_class($class);
         }
 
         $dm = $this->registry->getManagerForClass($class);
@@ -380,7 +380,7 @@ class ModelManager implements ModelManagerInterface
             $values['_sort_order'] = 'ASC';
         }
 
-        $values['_sort_by'] = is_string($fieldDescription->getOption('sortable')) ? $fieldDescription->getOption('sortable') : $fieldDescription->getName();
+        $values['_sort_by'] = \is_string($fieldDescription->getOption('sortable')) ? $fieldDescription->getOption('sortable') : $fieldDescription->getName();
 
         return ['filter' => $values];
     }

--- a/src/Util/ObjectAclManipulator.php
+++ b/src/Util/ObjectAclManipulator.php
@@ -77,7 +77,7 @@ class ObjectAclManipulator extends BaseObjectAclManipulator
                 }
             }
 
-            if (count($objectIds) > 0) {
+            if (\count($objectIds) > 0) {
                 list($batchAdded, $batchUpdated) = $this->configureAcls($output, $admin, $objectIdIterator, $securityIdentity);
                 $countAdded += $batchAdded;
                 $countUpdated += $batchUpdated;


### PR DESCRIPTION
Related to this problem: https://stackoverflow.com/questions/38440152/autocomplete-filter-in-sonata-admin-mongodb

I am targeting this branch, because the change is backward compatible.

## Changelog

```markdown
### Fixed
Fixes missing association admin class in datagrid filters.
```