### PR TITLE
Support doctrine/mongodb-odm ^2.x & doctrine/mongodb-odm-bundle ^4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require": {
         "php": "^7.1",
         "doctrine/mongodb-odm": "^1.0 || ^2.0",
-        "doctrine/mongodb-odm-bundle": "^4.0",
+        "doctrine/mongodb-odm-bundle": "^3.0 || ^4.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.8",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/mongodb-odm": "^1.0 || ^2.0",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/mongodb-odm": "^1.0",
-        "doctrine/mongodb-odm-bundle": "^3.0",
+        "doctrine/mongodb-odm": "^2.0",
+        "doctrine/mongodb-odm-bundle": "^4.0",
         "sonata-project/admin-bundle": "^3.31",
         "sonata-project/core-bundle": "^3.8",
         "symfony/config": "^2.8 || ^3.2 || ^4.0",

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Builder;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
@@ -74,7 +74,7 @@ class FormContractor implements FormContractorInterface
         $fieldDescription->setAdmin($admin);
         $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'standard'));
 
-        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY], true)) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY], true)) {
             $admin->attachAdminClass($fieldDescription);
         }
     }
@@ -142,7 +142,7 @@ class FormContractor implements FormContractorInterface
                 ));
             }
 
-            if (!\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY], true)) {
+            if (!\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY], true)) {
                 throw new \RuntimeException(sprintf(
                     'You are trying to add `sonata_type_admin` field `%s` which is not One-To-One or  Many-To-One.'
                     .' Maybe you want `sonata_type_collection` instead?',

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Builder;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -118,9 +118,9 @@ class ListBuilder implements ListBuilderInterface
             $template = $this->getTemplate($fieldDescription->getType());
 
             if (null === $template) {
-                if (ClassMetadataInfo::ONE === $fieldDescription->getMappingType()) {
+                if (ClassMetadata::ONE === $fieldDescription->getMappingType()) {
                     $template = '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig';
-                } elseif (ClassMetadataInfo::MANY === $fieldDescription->getMappingType()) {
+                } elseif (ClassMetadata::MANY === $fieldDescription->getMappingType()) {
                     $template = '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig';
                 }
             }
@@ -128,7 +128,7 @@ class ListBuilder implements ListBuilderInterface
             $fieldDescription->setTemplate($template);
         }
 
-        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY], true)) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY], true)) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Builder;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -101,9 +101,9 @@ class ShowBuilder implements ShowBuilderInterface
             $template = $this->getTemplate($fieldDescription->getType());
 
             if (null === $template) {
-                if (ClassMetadataInfo::ONE === $fieldDescription->getMappingType()) {
+                if (ClassMetadata::ONE === $fieldDescription->getMappingType()) {
                     $template = '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig';
-                } elseif (ClassMetadataInfo::MANY === $fieldDescription->getMappingType()) {
+                } elseif (ClassMetadata::MANY === $fieldDescription->getMappingType()) {
                     $template = '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig';
                 }
             }
@@ -111,7 +111,7 @@ class ShowBuilder implements ShowBuilderInterface
             $fieldDescription->setTemplate($template);
         }
 
-        if (\in_array($fieldDescription->getMappingType(), [ClassMetadataInfo::ONE, ClassMetadataInfo::MANY], true)) {
+        if (\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY], true)) {
             $admin->attachAdminClass($fieldDescription);
         }
     }

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -58,14 +58,14 @@ abstract class AbstractDateFilter extends Filter
                 return $this->applyTypeIsEqual($queryBuilder, $field, $data);
 
             case DateType::TYPE_GREATER_THAN:
-                if (!array_key_exists('value', $data) || !$data['value']) {
+                if (!\array_key_exists('value', $data) || !$data['value']) {
                     return;
                 }
 
                 return $this->applyTypeIsGreaterThan($queryBuilder, $field, $data);
 
             case DateType::TYPE_LESS_EQUAL:
-                if (!array_key_exists('value', $data) || !$data['value']) {
+                if (!\array_key_exists('value', $data) || !$data['value']) {
                     return;
                 }
 

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -27,7 +27,7 @@ class BooleanFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !\is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
 

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -27,7 +27,7 @@ class ChoiceFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !\is_array($data) || !array_key_exists('type', $data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
 

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -28,7 +28,7 @@ class ModelFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !\is_array($data) || !array_key_exists('value', $data)) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {
             return;
         }
 

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -25,7 +25,7 @@ class NumberFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $data)
     {
-        if (!$data || !\is_array($data) || !array_key_exists('value', $data) || !is_numeric($data['value'])) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || !is_numeric($data['value'])) {
             return;
         }
 

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -24,7 +24,7 @@ class StringFilter extends Filter
      */
     public function filter(ProxyQueryInterface $queryBuilder, $name, $field, $data)
     {
-        if (!$data || !\is_array($data) || !array_key_exists('value', $data) || null === $data['value']) {
+        if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || null === $data['value']) {
             return;
         }
 

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Guesser;
 
 use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\CoreBundle\Form\Type\BooleanType;
 use Sonata\CoreBundle\Form\Type\EqualType;
@@ -49,10 +49,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             $mapping = $metadata->fieldMappings[$propertyName];
 
             switch ($mapping['type']) {
-                case ClassMetadataInfo::ONE:
-                case ClassMetadataInfo::MANY:
-                    //case ClassMetadataInfo::MANY_TO_ONE:
-                    //case ClassMetadataInfo::MANY_TO_MANY:
+                case ClassMetadata::ONE:
+                case ClassMetadata::MANY:
+                    //case ClassMetadata::MANY_TO_ONE:
+                    //case ClassMetadata::MANY_TO_MANY:
 
                     $options['operator_type'] = EqualType::class;
                     $options['operator_options'] = [];

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -66,7 +66,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             }
         }
 
-        if (!array_key_exists($propertyName, $metadata->fieldMappings)) {
+        if (!\array_key_exists($propertyName, $metadata->fieldMappings)) {
             throw new MissingPropertyMetadataException($class, $property);
         }
 

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -51,9 +51,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser
             switch ($mapping['type']) {
                 case ClassMetadata::ONE:
                 case ClassMetadata::MANY:
-                    //case ClassMetadata::MANY_TO_ONE:
-                    //case ClassMetadata::MANY_TO_MANY:
-
                     $options['operator_type'] = EqualType::class;
                     $options['operator_options'] = [];
 

--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Guesser;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -35,10 +35,10 @@ class TypeGuesser extends AbstractTypeGuesser
             $mapping = $metadata->fieldMappings[$propertyName];
 
             switch ($mapping['type']) {
-                case ClassMetadataInfo::ONE:
+                case ClassMetadata::ONE:
                     return new TypeGuess('mongo_one', [], Guess::HIGH_CONFIDENCE);
 
-                case ClassMetadataInfo::MANY:
+                case ClassMetadata::MANY:
                     return new TypeGuess('mongo_many', [], Guess::HIGH_CONFIDENCE);
             }
         }

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -430,10 +430,10 @@ class ModelManager implements ModelManagerInterface
         foreach ($array as $name => $value) {
             $reflection_property = false;
             // property or association ?
-            if (array_key_exists($name, $metadata->fieldMappings)) {
+            if (\array_key_exists($name, $metadata->fieldMappings)) {
                 $property = $metadata->fieldMappings[$name]['fieldName'];
                 $reflection_property = $metadata->reflFields[$name];
-            } elseif (array_key_exists($name, $metadata->associationMappings)) {
+            } elseif (\array_key_exists($name, $metadata->associationMappings)) {
                 $property = $metadata->associationMappings[$name]['fieldName'];
             } else {
                 $property = $name;

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -201,7 +201,7 @@ class FieldDescriptionTest extends TestCase
             ->getMock();
         $mockedObject->expects($this->once())
             ->method('myMethod')
-            ->will($this->returnValue('myMethodValue'));
+            ->willReturn('myMethodValue');
 
         $field = new FieldDescription();
         $field->setOption('code', 'myMethod');
@@ -218,7 +218,7 @@ class FieldDescriptionTest extends TestCase
             ->getMock();
         $mockedObject->expects($this->never())
             ->method('myMethod')
-            ->will($this->returnValue('myMethodValue'));
+            ->willReturn('myMethodValue');
 
         $field = new FieldDescription();
 

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
@@ -107,7 +107,7 @@ class FormContractorTest extends TestCase
         }
 
         // admin type
-        $fieldDescription->method('getMappingType')->willReturn(ClassMetadataInfo::ONE);
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE);
         foreach ($adminTypes as $formType) {
             $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
             $this->assertSame($fieldDescription, $options['sonata_field_description']);
@@ -117,7 +117,7 @@ class FormContractorTest extends TestCase
         }
 
         // collection type
-        $fieldDescription->method('getMappingType')->willReturn(ClassMetadataInfo::MANY);
+        $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::MANY);
         foreach ($collectionTypes as $index => $formType) {
             $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
             $this->assertSame($fieldDescription, $options['sonata_field_description']);

--- a/tests/Filter/FilterWithQueryBuilderTest.php
+++ b/tests/Filter/FilterWithQueryBuilderTest.php
@@ -26,18 +26,18 @@ abstract class FilterWithQueryBuilderTest extends TestCase
         $this->queryBuilder
                 ->expects($this->any())
                 ->method('field')
-                ->will($this->returnSelf())
+                ->willReturnSelf()
         ;
         $this->expr = $this->createMock('Doctrine\ODM\MongoDB\Query\Expr');
         $this->expr
             ->expects($this->any())
             ->method('field')
-            ->will($this->returnSelf())
+            ->willReturnSelf()
         ;
         $this->queryBuilder
             ->expects($this->any())
             ->method('expr')
-            ->will($this->returnValue($this->expr))
+            ->willReturn($this->expr)
         ;
     }
 

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadataInfo;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Sonata\CoreBundle\Form\Type\EqualType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
@@ -98,7 +98,7 @@ class ModelFilterTest extends FilterWithQueryBuilderTest
         $this->expectException(\RuntimeException::class);
 
         $filter = new ModelFilter();
-        $filter->initialize('field_name', ['mapping_type' => ClassMetadataInfo::ONE, 'field_mapping' => true]);
+        $filter->initialize('field_name', ['mapping_type' => ClassMetadata::ONE, 'field_mapping' => true]);
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -110,7 +110,7 @@ class ModelFilterTest extends FilterWithQueryBuilderTest
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
-            'mapping_type' => ClassMetadataInfo::ONE,
+            'mapping_type' => ClassMetadata::ONE,
             'field_name' => 'field_name',
             'association_mapping' => [
                 'fieldName' => 'association_mapping',
@@ -128,7 +128,7 @@ class ModelFilterTest extends FilterWithQueryBuilderTest
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
-            'mapping_type' => ClassMetadataInfo::ONE,
+            'mapping_type' => ClassMetadata::ONE,
             'field_name' => 'field_name',
             'parent_association_mappings' => [
                 [

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -34,8 +34,8 @@ class ModelFilterTest extends FilterWithQueryBuilderTest
     public function getFieldDescription(array $options)
     {
         $fieldDescription = $this->createMock('Sonata\AdminBundle\Admin\FieldDescriptionInterface');
-        $fieldDescription->expects($this->once())->method('getOptions')->will($this->returnValue($options));
-        $fieldDescription->expects($this->once())->method('getName')->will($this->returnValue('field_name'));
+        $fieldDescription->expects($this->once())->method('getOptions')->willReturn($options);
+        $fieldDescription->expects($this->once())->method('getName')->willReturn('field_name');
 
         return $fieldDescription;
     }

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -35,6 +35,9 @@ class FilterTypeGuesserTest extends TestCase
 
         $class = 'My\Model';
         $property = 'whatever';
+
+        $this->metadata->hasAssociation($property)->willReturn(false);
+
         $this->modelManager->getParentMetadataForProperty($class, $property)->willReturn([
             $this->metadata->reveal(),
             $property,


### PR DESCRIPTION
- support both version of `doctrine/mongodb-odm` (`^1.0 || ^2.0`)
    - https://github.com/doctrine/mongodb-odm/blob/master/UPGRADE-2.0.md
    - **BC**: https://github.com/doctrine/mongodb-odm/pull/2069
- support both version of  `doctrine/mongodb-odm-bundle` (`^3.0 || ^4.0`) 
    - https://github.com/doctrine/DoctrineMongoDBBundle/blob/master/UPGRADE-4.0.md
- run php-cs fixer _(lint CI build)_
- updated `FilterTypeGuesserTest`

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is not BC.


