### PR TITLE
Remove all special case for ChoiceFilter

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -36,10 +36,6 @@ class ChoiceFilter extends Filter
                 return;
             }
 
-            if (\in_array('all', $data['value'], true)) {
-                return;
-            }
-
             if (ChoiceType::TYPE_NOT_CONTAINS === $data['type']) {
                 $queryBuilder->field($field)->notIn($data['value']);
             } else {
@@ -48,7 +44,7 @@ class ChoiceFilter extends Filter
 
             $this->active = true;
         } else {
-            if ('' === $data['value'] || null === $data['value'] || false === $data['value'] || 'all' === $data['value']) {
+            if ('' === $data['value'] || null === $data['value'] || false === $data['value']) {
                 return;
             }
 

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -32,7 +32,6 @@ class ChoiceFilterTest extends FilterWithQueryBuilderTest
         ;
 
         $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'all');
         $filter->filter($builder, 'alias', 'field', []);
 
         $this->assertFalse($filter->isActive());


### PR DESCRIPTION
Same as https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1011

I am targeting this branch, because unfortunally this is a BC-break.

The `all` special case make no sens to me.
- It's not documented
- I can't filter by the `all` value if I have the `all` value in database.
- It does nothing, it's the same than an empty input.

## Changelog

```markdown
### Removed
- Special case for the `all` value in ChoiceFilter
```

If accepted, I'll make the PR for the other ORM bundle.