### PR TITLE
Remove Default sort by

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^7.1",
         "doctrine/mongodb-odm": "^1.3 || ^2.0",
         "doctrine/mongodb-odm-bundle": "^3.0 || ^4.0",
-        "sonata-project/admin-bundle": "^3.61",
+        "sonata-project/admin-bundle": "^3.63",
         "sonata-project/core-bundle": "^3.17",
         "symfony/config": "^3.4 || ^4.2",
         "symfony/dependency-injection": "^3.4 || ^4.2",

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -403,8 +403,6 @@ class ModelManager implements ModelManagerInterface
     public function getDefaultSortValues($class)
     {
         return [
-            '_sort_order' => 'ASC',
-            '_sort_by' => $this->getModelIdentifier($class),
             '_page' => 1,
             '_per_page' => 25,
         ];


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

Same than https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1004

## Changelog
```markdown
### Removed
- The modelManager getDefaultSortValues does not have default `_sort_by` value anymore.
```