### PR TITLE
Add tests to ModelManager and DateFilter

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,12 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager
+
+Deprecated `camelize()` method.
+
+Deprecated not passing an instance of `PropertyAccessInterface` as second argument in the constructor.
+
 ### Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription
 
 Deprecated `getTargetEntity()`, use `getTargetModel()` instead.

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/doctrine-bridge": "^4.4",
         "symfony/form": "^4.4",
         "symfony/http-kernel": "^4.4",
+        "symfony/property-access": "^4.4",
         "twig/twig": "^2.6"
     },
     "provide": {

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -14,9 +14,15 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 class DateFilter extends AbstractDateFilter
 {
+    public function getFieldType(): string
+    {
+        return $this->getOption('field_type', DateType::class);
+    }
+
     /**
      * @param string $field
      * @param array  $data

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 class DateTimeFilter extends AbstractDateFilter
 {
@@ -23,6 +24,11 @@ class DateTimeFilter extends AbstractDateFilter
      * @var bool
      */
     protected $time = true;
+
+    public function getFieldType(): string
+    {
+        return $this->getOption('field_type', DateTimeType::class);
+    }
 
     /**
      * @param string $field

--- a/src/Resources/config/doctrine_mongodb.xml
+++ b/src/Resources/config/doctrine_mongodb.xml
@@ -3,6 +3,7 @@
     <services>
         <service id="sonata.admin.manager.doctrine_mongodb" class="Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager">
             <argument type="service" id="doctrine_mongodb" on-invalid="ignore"/>
+            <argument type="service" id="property_accessor"/>
             <tag name="sonata.admin.manager"/>
         </service>
         <!-- FormBuilder -->

--- a/tests/Filter/DateTimeFilterTest.php
+++ b/tests/Filter/DateTimeFilterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeFilter;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+
+final class DateTimeFilterTest extends FilterWithQueryBuilderTest
+{
+    public function testEmpty(): void
+    {
+        $filter = new DateTimeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery($this->getQueryBuilder());
+
+        $builder->getQueryBuilder()
+            ->expects($this->never())
+            ->method('field')
+        ;
+
+        $filter->filter($builder, 'alias', 'field', null);
+        $filter->filter($builder, 'alias', 'field', '');
+        $filter->filter($builder, 'alias', 'field', []);
+
+        $this->assertFalse($filter->isActive());
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame(DateTimeType::class, (new DateTimeFilter())->getFieldType());
+    }
+
+    /**
+     * @dataProvider getExamples
+     */
+    public function testFilter(array $data, string $method): void
+    {
+        $filter = new DateTimeFilter();
+        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+
+        $builder = new ProxyQuery($this->getQueryBuilder());
+
+        $builder->getQueryBuilder()
+            ->expects($this->once())
+            ->method($method)
+            ->with($data['value'] ?? null)
+        ;
+
+        $filter->filter($builder, 'alias', 'field', $data);
+
+        $this->assertTrue($filter->isActive());
+    }
+
+    public function getExamples(): array
+    {
+        return [
+            [['type' => DateType::TYPE_EQUAL, 'value' => new \DateTime('now')], 'range'],
+            [['type' => DateType::TYPE_GREATER_EQUAL, 'value' => new \DateTime('now')], 'gte'],
+            [['type' => DateType::TYPE_GREATER_THAN, 'value' => new \DateTime('now')], 'gt'],
+            [['type' => DateType::TYPE_LESS_EQUAL, 'value' => new \DateTime('now')], 'lte'],
+            [['type' => DateType::TYPE_LESS_THAN, 'value' => new \DateTime('now')], 'lt'],
+            [['type' => DateType::TYPE_NULL], 'equals'],
+            [['type' => DateType::TYPE_NOT_NULL], 'notEqual'],
+            [['value' => new \DateTime('now')], 'range'],
+        ];
+    }
+}

--- a/tests/Fixtures/Document/AbstractDocument.php
+++ b/tests/Fixtures/Document/AbstractDocument.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+abstract class AbstractDocument
+{
+}

--- a/tests/Fixtures/Document/AssociatedDocument.php
+++ b/tests/Fixtures/Document/AssociatedDocument.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+class AssociatedDocument
+{
+    private $plainField;
+    private $embeddedDocument;
+
+    public function __construct(int $plainField, EmbeddedDocument $embeddedDocument)
+    {
+        $this->plainField = $plainField;
+        $this->embeddedDocument = $embeddedDocument;
+    }
+
+    public function getPlainField(): int
+    {
+        return $this->plainField;
+    }
+}

--- a/tests/Fixtures/Document/ContainerDocument.php
+++ b/tests/Fixtures/Document/ContainerDocument.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+class ContainerDocument
+{
+    private $plainField;
+    private $associatedDocument;
+    private $embeddedDocument;
+
+    public function __construct(AssociatedDocument $associatedDocument, EmbeddedDocument $embeddedDocument)
+    {
+        $this->associatedDocument = $associatedDocument;
+        $this->embeddedDocument = $embeddedDocument;
+    }
+
+    public function getAssociatedDocument(): AssociatedDocument
+    {
+        return $this->associatedDocument;
+    }
+}

--- a/tests/Fixtures/Document/EmbeddedDocument.php
+++ b/tests/Fixtures/Document/EmbeddedDocument.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+class EmbeddedDocument
+{
+    /**
+     * @var bool
+     */
+    protected $plainField;
+}

--- a/tests/Fixtures/Document/ProtectedDocument.php
+++ b/tests/Fixtures/Document/ProtectedDocument.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+class ProtectedDocument
+{
+    private function __construct()
+    {
+    }
+}

--- a/tests/Fixtures/Document/SimpleDocument.php
+++ b/tests/Fixtures/Document/SimpleDocument.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+class SimpleDocument
+{
+    public $schwifty;
+    private $schmeckles;
+    private $multiWordProperty;
+    private $plumbus;
+
+    public function getSchmeckles()
+    {
+        return $this->schmeckles;
+    }
+
+    public function setSchmeckles($value): void
+    {
+        $this->schmeckles = $value;
+    }
+
+    public function getMultiWordProperty()
+    {
+        return $this->multiWordProperty;
+    }
+
+    public function setMultiWordProperty($value): void
+    {
+        $this->multiWordProperty = $value;
+    }
+}

--- a/tests/Fixtures/Document/SimpleDocumentWithPrivateSetter.php
+++ b/tests/Fixtures/Document/SimpleDocumentWithPrivateSetter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+final class SimpleDocumentWithPrivateSetter
+{
+    private $schmeckles;
+
+    public function __construct(int $schmeckles)
+    {
+        $this->setSchmeckles($schmeckles);
+    }
+
+    public function getSchmeckles(): int
+    {
+        return $this->schmeckles;
+    }
+
+    private function setSchmeckles($value): void
+    {
+        $this->schmeckles = $value;
+    }
+}

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -13,19 +13,27 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AbstractDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AssociatedDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\ContainerDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\EmbeddedDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\ProtectedDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\SimpleDocument;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 class ModelManagerTest extends TestCase
 {
-    public function testFilterEmpty(): void
-    {
-        $registry = $this->createMock(ManagerRegistry::class);
-
-        new ModelManager($registry);
-    }
-
     /**
      * @dataProvider getWrongDocuments
      *
@@ -33,7 +41,7 @@ class ModelManagerTest extends TestCase
      */
     public function testNormalizedIdentifierException($document): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createStub(ManagerRegistry::class);
 
         $model = new ModelManager($registry);
 
@@ -55,10 +63,336 @@ class ModelManagerTest extends TestCase
 
     public function testGetNormalizedIdentifierNull(): void
     {
-        $registry = $this->createMock(ManagerRegistry::class);
+        $registry = $this->createStub(ManagerRegistry::class);
 
         $model = new ModelManager($registry);
 
         $this->assertNull($model->getNormalizedIdentifier(null));
+    }
+
+    public function testSortParameters(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $manager = new ModelManager($registry);
+
+        $datagrid1 = $this->createStub(Datagrid::class);
+        $datagrid2 = $this->createStub(Datagrid::class);
+
+        $field1 = new FieldDescription();
+        $field1->setName('field1');
+
+        $field2 = new FieldDescription();
+        $field2->setName('field2');
+
+        $field3 = new FieldDescription();
+        $field3->setName('field3');
+        $field3->setOption('sortable', 'field3sortBy');
+
+        $datagrid1
+            ->method('getValues')
+            ->willReturn([
+                '_sort_by' => $field1,
+                '_sort_order' => 'ASC',
+            ]);
+
+        $datagrid2
+            ->method('getValues')
+            ->willReturn([
+                '_sort_by' => $field3,
+                '_sort_order' => 'ASC',
+            ]);
+
+        $parameters = $manager->getSortParameters($field1, $datagrid1);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field1', $parameters['filter']['_sort_by']);
+
+        $parameters = $manager->getSortParameters($field2, $datagrid1);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field2', $parameters['filter']['_sort_by']);
+
+        $parameters = $manager->getSortParameters($field3, $datagrid1);
+
+        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+
+        $parameters = $manager->getSortParameters($field3, $datagrid2);
+
+        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
+        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+    }
+
+    public function testGetParentMetadataForProperty(): void
+    {
+        $containerDocumentClass = ContainerDocument::class;
+        $associatedDocumentClass = AssociatedDocument::class;
+        $embeddedDocumentClass = EmbeddedDocument::class;
+
+        $dm = $this->createStub(DocumentManager::class);
+
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $modelManager = new ModelManager($registry);
+
+        $registry
+            ->method('getManagerForClass')
+            ->willReturn($dm);
+
+        $metadataFactory = $this->createStub(ClassMetadataFactory::class);
+
+        $dm
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+
+        $containerDocumentMetadata = $this->getMetadataForContainerDocument();
+        $associatedDocumentMetadata = $this->getMetadataForAssociatedDocument();
+        $embeddedDocumentMetadata = $this->getMetadataForEmbeddedDocument();
+
+        $metadataFactory->method('getMetadataFor')
+            ->willReturnMap(
+                [
+                    [$containerDocumentClass, $containerDocumentMetadata],
+                    [$embeddedDocumentClass, $embeddedDocumentMetadata],
+                    [$associatedDocumentClass, $associatedDocumentMetadata],
+                ]
+            );
+
+        /** @var ClassMetadata $metadata */
+        [$metadata, $lastPropertyName] = $modelManager
+            ->getParentMetadataForProperty($containerDocumentClass, 'plainField');
+        $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'integer');
+
+        [$metadata, $lastPropertyName] = $modelManager
+            ->getParentMetadataForProperty($containerDocumentClass, 'associatedDocument.plainField');
+        $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'string');
+
+        [$metadata, $lastPropertyName] = $modelManager
+            ->getParentMetadataForProperty($containerDocumentClass, 'embeddedDocument.plainField');
+        $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
+
+        $this->assertSame($metadata->fieldMappings[$lastPropertyName]['type'], 'boolean');
+    }
+
+    public function testModelReverseTransform(): void
+    {
+        $class = SimpleDocument::class;
+
+        $manager = $this->createModelManager($class);
+        $object = $manager->modelReverseTransform(
+            $class,
+            [
+                'schmeckles' => 42,
+                'multi_word_property' => 'hello',
+                'schwifty' => true,
+            ]
+        );
+        $this->assertInstanceOf($class, $object);
+        $this->assertSame(42, $object->getSchmeckles());
+        $this->assertSame('hello', $object->getMultiWordProperty());
+        $this->assertTrue($object->schwifty);
+    }
+
+    public function testCollections(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+        $model = new ModelManager($registry);
+
+        $collection = $model->getModelCollectionInstance('whyDoWeEvenHaveThisParameter');
+        $this->assertInstanceOf(ArrayCollection::class, $collection);
+
+        $item1 = new \stdClass();
+        $item2 = new \stdClass();
+        $model->collectionAddElement($collection, $item1);
+        $model->collectionAddElement($collection, $item2);
+
+        $this->assertTrue($model->collectionHasElement($collection, $item1));
+
+        $model->collectionRemoveElement($collection, $item1);
+
+        $this->assertFalse($model->collectionHasElement($collection, $item1));
+
+        $model->collectionClear($collection);
+
+        $this->assertTrue($collection->isEmpty());
+    }
+
+    public function testModelTransform(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+        $model = new ModelManager($registry);
+
+        $instance = new \stdClass();
+        $result = $model->modelTransform('thisIsNotUsed', $instance);
+
+        $this->assertSame($instance, $result);
+    }
+
+    public function testGetPaginationParameters(): void
+    {
+        $datagrid = $this->createMock(DatagridInterface::class);
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $datagrid->expects($this->once())
+            ->method('getValues')
+            ->willReturn(['_sort_by' => $fieldDescription]);
+
+        $fieldDescription->expects($this->once())
+            ->method('getName')
+            ->willReturn($name = 'test');
+
+        $model = new ModelManager($registry);
+
+        $result = $model->getPaginationParameters($datagrid, $page = 5);
+
+        $this->assertSame($page, $result['filter']['_page']);
+        $this->assertSame($name, $result['filter']['_sort_by']);
+    }
+
+    public function testGetModelInstanceException(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $model = new ModelManager($registry);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $model->getModelInstance(AbstractDocument::class);
+    }
+
+    public function testGetModelInstanceForProtectedDocument(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $model = new ModelManager($registry);
+
+        $this->assertInstanceOf(ProtectedDocument::class, $model->getModelInstance(ProtectedDocument::class));
+    }
+
+    public function testFindBadId(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $model = new ModelManager($registry);
+
+        $this->assertNull($model->find('notImportant', null));
+    }
+
+    public function testGetUrlSafeIdentifierException(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $model = new ModelManager($registry);
+
+        $this->expectException(\RuntimeException::class);
+
+        $model->getNormalizedIdentifier(new \stdClass());
+    }
+
+    public function testGetUrlSafeIdentifierNull(): void
+    {
+        $registry = $this->createStub(ManagerRegistry::class);
+
+        $model = new ModelManager($registry);
+
+        $this->assertNull($model->getNormalizedIdentifier(null));
+    }
+
+    private function createModelManager(string $class): ModelManager
+    {
+        $metadataFactory = $this->createMock(ClassMetadataFactory::class);
+        $modelManager = $this->createMock(ObjectManager::class);
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $classMetadata = new ClassMetadata($class);
+        $classMetadata->reflClass = new \ReflectionClass($class);
+
+        $modelManager->expects($this->once())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+        $metadataFactory->expects($this->once())
+            ->method('getMetadataFor')
+            ->with($class)
+            ->willReturn($classMetadata);
+        $registry->expects($this->once())
+            ->method('getManagerForClass')
+            ->with($class)
+            ->willReturn($modelManager);
+
+        return new ModelManager($registry);
+    }
+
+    private function getMetadataForEmbeddedDocument(): ClassMetadata
+    {
+        $metadata = new ClassMetadata(EmbeddedDocument::class);
+
+        $metadata->fieldMappings = [
+            'plainField' => [
+                'fieldName' => 'plainField',
+                'columnName' => 'plainField',
+                'type' => 'boolean',
+            ],
+        ];
+
+        return $metadata;
+    }
+
+    private function getMetadataForAssociatedDocument(): ClassMetadata
+    {
+        $embeddedDocumentClass = EmbeddedDocument::class;
+
+        $metadata = new ClassMetadata(AssociatedDocument::class);
+
+        $metadata->fieldMappings = [
+            'plainField' => [
+                'fieldName' => 'plainField',
+                'name' => 'plainField',
+                'columnName' => 'plainField',
+                'type' => 'string',
+            ],
+        ];
+
+        $metadata->mapOneEmbedded([
+            'fieldName' => 'embeddedDocument',
+            'name' => 'embeddedDocument',
+            'targetDocument' => $embeddedDocumentClass,
+        ]);
+
+        return $metadata;
+    }
+
+    private function getMetadataForContainerDocument(): ClassMetadata
+    {
+        $containerDocumentClass = ContainerDocument::class;
+        $associatedDocumentClass = AssociatedDocument::class;
+        $embeddedDocumentClass = EmbeddedDocument::class;
+
+        $metadata = new ClassMetadata($containerDocumentClass);
+
+        $metadata->fieldMappings = [
+            'plainField' => [
+                'fieldName' => 'plainField',
+                'name' => 'plainField',
+                'columnName' => 'plainField',
+                'type' => 'integer',
+            ],
+        ];
+
+        $metadata->associationMappings['associatedDocument'] = [
+            'fieldName' => 'associatedDocument',
+            'name' => 'associatedDocument',
+            'targetDocument' => $associatedDocumentClass,
+            'sourceDocument' => $containerDocumentClass,
+        ];
+
+        $metadata->mapOneEmbedded([
+            'fieldName' => 'embeddedDocument',
+            'name' => 'embeddedDocument',
+            'targetDocument' => $embeddedDocumentClass,
+        ]);
+
+        return $metadata;
     }
 }


### PR DESCRIPTION
## Subject

This is a part of https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/360, there are some comments there about these changes.

I am targeting this branch, because this is BCish.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `AbstractDateFilter::typeRequiresValue`.
- Deprecated `ModelManager::camelize`.
- Deprecated constructing `ModelManager` without passing an instance of `PropertyAccessorInterface` as second argument.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
