### PR TITLE
Fix resetting pagination parameters

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -94,7 +94,7 @@ class ProxyQuery implements ProxyQueryInterface
     public function setFirstResult($firstResult)
     {
         $this->firstResult = $firstResult;
-        $this->queryBuilder->skip($firstResult);
+        $this->queryBuilder->skip($firstResult ?? 0);
     }
 
     public function getFirstResult()
@@ -105,7 +105,9 @@ class ProxyQuery implements ProxyQueryInterface
     public function setMaxResults($maxResults)
     {
         $this->maxResults = $maxResults;
-        $this->queryBuilder->limit($maxResults);
+
+        // @see https://docs.mongodb.com/manual/reference/method/cursor.limit/#zero-value
+        $this->queryBuilder->limit($maxResults ?? 0);
     }
 
     public function getMaxResults()

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Datagrid;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+
+final class ProxyQueryTest extends TestCase
+{
+    /**
+     * @var Builder&MockObject
+     */
+    private $queryBuilder;
+
+    protected function setUp(): void
+    {
+        $this->queryBuilder = $this->createMock(Builder::class);
+    }
+
+    public function testSetLimitToZeroWhenResettingMaxResults(): void
+    {
+        $proxyQuery = new ProxyQuery($this->queryBuilder);
+
+        $this->queryBuilder
+            ->expects($this->once())
+            ->method('limit')
+            ->with(0);
+
+        $proxyQuery->setMaxResults(null);
+    }
+
+    public function testSetSkipToZeroWhenResettingFirstResult(): void
+    {
+        $proxyQuery = new ProxyQuery($this->queryBuilder);
+
+        $this->queryBuilder
+            ->expects($this->once())
+            ->method('skip')
+            ->with(0);
+
+        $proxyQuery->setFirstResult(null);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

As pointed out in https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/issues/370, [`Builder::skip`](https://github.com/doctrine/mongodb-odm/blob/2.0.x/lib/Doctrine/ODM/MongoDB/Query/Builder.php#L1415) and [`Builder::limit`](https://github.com/doctrine/mongodb-odm/blob/2.0.x/lib/Doctrine/ODM/MongoDB/Query/Builder.php#L864) methods expect an `int` value in `mongodb/odm` version `2.x` (in `1.3.x` [it was casted to int internally](https://github.com/doctrine/mongodb/blob/master/lib/Doctrine/MongoDB/Query/Builder.php#L916)).

So when the [pagination parameters are resetted in batch actions, they receive `null`](https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Controller/CRUDController.php#L517-L518).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #370.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed passing `null` to `Doctrine\ODM\MongoDB\Query\Builder::skip` and `Doctrine\ODM\MongoDB\Query\Builder::limit`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
