### PR TITLE
Use deprecated tag instead of sonata_template_deprecate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/form": "^3.4 || ^4.2",
         "symfony/http-kernel": "^3.4 || ^4.2",
         "twig/extensions": "^1.0",
-        "twig/twig": "^1.34 || ^2.0"
+        "twig/twig": "^2.6"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"

--- a/src/Resources/views/CRUD/edit_mongo_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_association_script.html.twig
@@ -16,7 +16,7 @@ This code manage the many-to-[one|many] association field popup
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+{% deprecated 'The "edit_mongo_association_script.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_script.html.twig" instead.' %}
 
 {% autoescape false %}
 

--- a/src/Resources/views/CRUD/edit_mongo_collection.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_collection.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_one_to_many.html.twig' %}
+{% deprecated 'The "edit_mongo_collection.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_one_to_many.html.twig" instead.' %}
 
 {% if not sonata_admin.field_description.hasassociationadmin %}
     {% for element in value %}

--- a/src/Resources/views/CRUD/edit_mongo_many.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_many.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_to_many.html.twig' %}
+{% deprecated 'The "edit_mongo_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_to_many.html.twig" instead.' %}
 
 {% if sonata_admin.field_description.associationadmin %}
     <div id="field_container_{{ id }}" class="field-container">

--- a/src/Resources/views/CRUD/edit_mongo_one.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_one.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_to_one.html.twig' %}
+{% deprecated 'The "edit_mongo_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_to_one.html.twig" instead.' %}
 
 {% if not sonata_admin.field_description.hasassociationadmin%}
     {{ value|render_relation_element(sonata_admin.field_description) }}

--- a/src/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
+++ b/src/Resources/views/CRUD/edit_mongo_one_association_script.html.twig
@@ -16,7 +16,7 @@ This code manage the one-to-many association field popup
 
 #}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+{% deprecated 'The "edit_mongo_one_association_script.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/edit_many_script.html.twig" instead.' %}
 
 {% autoescape false %}
 
@@ -48,7 +48,7 @@ This code manage the one-to-many association field popup
                 if (!html.length) {
                     return;
                 }
-                
+
                 var $newForm = jQuery(html);
                 var $oldForm = jQuery('#field_container_{{ id }}');
 
@@ -59,9 +59,9 @@ This code manage the one-to-many association field popup
                 });
 
                 $oldForm.replaceWith($newForm);  // replace the html
-                
+
                 Admin.shared_setup(jQuery('#field_container_{{ id }}'));
-                    
+
                 if(jQuery('input[type="file"]', form).length > 0) {
                     jQuery(form).attr('enctype', 'multipart/form-data');
                     jQuery(form).attr('encoding', 'multipart/form-data');

--- a/src/Resources/views/CRUD/list_mongo_many.html.twig
+++ b/src/Resources/views/CRUD/list_mongo_many.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig' %}
+{% deprecated 'The "list_mongo_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_many_to_many.html.twig" instead.' %}
 
 {% block field%}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute('edit') and field_description.associationadmin.isGranted('edit')%}

--- a/src/Resources/views/CRUD/list_mongo_one.html.twig
+++ b/src/Resources/views/CRUD/list_mongo_one.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends admin.getTemplate('base_list_field') %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig' %}
+{% deprecated 'The "list_mongo_one.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/list_many_to_one.html.twig" instead.' %}
 
 {% block field %}
     {% if value %}

--- a/src/Resources/views/CRUD/show_mongo_many.html.twig
+++ b/src/Resources/views/CRUD/show_mongo_many.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
-{% sonata_template_deprecate '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig' %}
+{% deprecated 'The "show_mongo_many.html.twig" template is deprecated, use "@SonataAdmin/CRUD/Association/show_many_to_many.html.twig" instead.' %}
 
 {% block field%}
     <ul class="sonata-ba-show-many-to-many">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/956

With [`deprecated` tag](https://twig.symfony.com/doc/2.x/tags/deprecated.html) only shows the deprecation notices when the template is actually used.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use `deprecated` tag instead of `sonata_template_deprecate` to not throw unwanted deprecation notices.
- Bump Twig to 2.6
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
