### PR TITLE
Replace SonataCoreBundle dependency with form-extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/mongodb-odm": "^1.3 || ^2.0",
         "doctrine/mongodb-odm-bundle": "^3.0 || ^4.0",
         "sonata-project/admin-bundle": "^3.61",
-        "sonata-project/core-bundle": "^3.17",
+        "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",
         "symfony/doctrine-bridge": "^4.4",

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -23,7 +23,6 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Form\Type\ModelTypeList;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
 use Sonata\Form\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -150,7 +149,8 @@ class FormContractor implements FormContractorInterface
             $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
         } elseif ($this->checkFormClass($type, [
             CollectionType::class,
-            DeprecatedCollectionType::class,
+            // NEXT_MAJOR: Remove 'Sonata\CoreBundle\Form\Type\CollectionType'
+            'Sonata\CoreBundle\Form\Type\CollectionType',
         ])) {
             if (!$fieldDescription->getAssociationAdmin()) {
                 throw new \RuntimeException(sprintf(

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -23,7 +23,6 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\CoreBundle\Form\Type\CollectionType as DeprecatedCollectionType;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
 use Sonata\Form\Type\CollectionType;
@@ -84,7 +83,6 @@ class FormContractorTest extends TestCase
             AdminType::class,
         ];
         $collectionTypes = [
-            DeprecatedCollectionType::class,
             CollectionType::class,
         ];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1048

I am targeting this branch, because these changes are BC.

Part of sonata-project/dev-kit#697

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `sonata-project/form-extensions` dependency.
### Removed
- Removed SonataCoreBundle dependency.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
