### PR TITLE
Add missing methods to ModelManager and FieldDescription

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,11 +1,18 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription
+
+Deprecated `getTargetEntity()`, use `getTargetModel()` instead.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/collections": "^1.6",
         "doctrine/mongodb-odm": "^1.3 || ^2.0",
         "doctrine/mongodb-odm-bundle": "^3.0 || ^4.0",
-        "sonata-project/admin-bundle": "^3.61",
+        "sonata-project/admin-bundle": "^3.69",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -42,13 +42,32 @@ class FieldDescription extends BaseFieldDescription
     }
 
     /**
-     * {@inheritdoc}
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0. Use FieldDescription::getTargetModel() instead.
      */
     public function getTargetEntity()
+    {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use %s::getTargetModel() instead.',
+            __METHOD__,
+            __CLASS__
+        ), E_USER_DEPRECATED);
+
+        return $this->getTargetModel();
+    }
+
+    /**
+     * @final since sonata-project/doctrine-mongodb-admin-bundle 3.x.
+     */
+    public function getTargetModel(): ?string
     {
         if ($this->associationMapping) {
             return $this->associationMapping['targetDocument'];
         }
+
+        return null;
     }
 
     /**

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -110,7 +110,7 @@ class FormContractor implements FormContractorInterface
                 );
             }
 
-            $options['class'] = $fieldDescription->getTargetEntity();
+            $options['class'] = $fieldDescription->getTargetModel();
             $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
 
             if ($this->checkFormClass($type, [ModelAutocompleteType::class])) {
@@ -119,7 +119,7 @@ class FormContractor implements FormContractorInterface
                         'The current field `%s` is not linked to an admin.'
                         .' Please create one for the target entity: `%s`',
                         $fieldDescription->getName(),
-                        $fieldDescription->getTargetEntity()
+                        $fieldDescription->getTargetModel()
                     ));
                 }
             }
@@ -129,7 +129,7 @@ class FormContractor implements FormContractorInterface
                     'The current field `%s` is not linked to an admin.'
                     .' Please create one for the target entity : `%s`',
                     $fieldDescription->getName(),
-                    $fieldDescription->getTargetEntity()
+                    $fieldDescription->getTargetModel()
                 ));
             }
 
@@ -157,7 +157,7 @@ class FormContractor implements FormContractorInterface
                     'The current field `%s` is not linked to an admin.'
                     .' Please create one for the target entity : `%s`',
                     $fieldDescription->getName(),
-                    $fieldDescription->getTargetEntity()
+                    $fieldDescription->getTargetModel()
                 ));
             }
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -417,6 +417,11 @@ class ModelManager implements ModelManagerInterface
         ];
     }
 
+    public function getDefaultPerPageOptions(string $class): array
+    {
+        return [10, 25, 50, 100, 250];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Admin;
 
-use Doctrine\Common\Inflector\Inflector;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -108,13 +107,6 @@ class FieldDescriptionTest extends TestCase
         $field->setMappingType('string');
         $this->assertSame('string', $field->getMappingType());
         $this->assertSame('integer', $field->getType());
-    }
-
-    public function testCamelize(): void
-    {
-        $this->assertSame('FooBar', Inflector::classify('foo_bar'));
-        $this->assertSame('FooBar', Inflector::classify('foo bar'));
-        $this->assertSame('FOoBar', Inflector::classify('fOo bar'));
     }
 
     public function testSetName(): void

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -288,6 +288,11 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame('position', $field->getFieldName());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetTargetEntity(): void
     {
         $assocationMapping = [
@@ -303,6 +308,23 @@ class FieldDescriptionTest extends TestCase
         $field->setAssociationMapping($assocationMapping);
 
         $this->assertSame('someValue', $field->getTargetEntity());
+    }
+
+    public function testGetTargetModel(): void
+    {
+        $assocationMapping = [
+            'type' => 'integer',
+            'fieldName' => 'position',
+            'targetDocument' => 'someValue',
+        ];
+
+        $field = new FieldDescription();
+
+        $this->assertNull($field->getTargetModel());
+
+        $field->setAssociationMapping($assocationMapping);
+
+        $this->assertSame('someValue', $field->getTargetModel());
     }
 
     public function testIsIdentifierFromFieldMapping(): void

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
 use Sonata\Form\Type\CollectionType;
@@ -68,9 +69,10 @@ class FormContractorTest extends TestCase
         $admin->method('getModelManager')->willReturn($modelManager);
         $admin->method('getClass')->willReturn($modelClass);
 
-        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        // NEXT_MAJOR: Mock `FieldDescriptionInterface` instead and replace `getTargetEntity()` with `getTargetModel().
+        $fieldDescription = $this->createMock(FieldDescription::class);
         $fieldDescription->method('getAdmin')->willReturn($admin);
-        $fieldDescription->method('getTargetEntity')->willReturn($modelClass);
+        $fieldDescription->method('getTargetModel')->willReturn($modelClass);
         $fieldDescription->method('getAssociationAdmin')->willReturn($admin);
 
         $modelTypes = [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This PR adds:
 - `ModelManager::getDefaultPerPageOptions` (Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1044).
 - `FieldDescription::getTargetModel` (Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1049/files).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ModelManager::getDefaultPerPageOptions()`.
- Added `FieldDescription::getTargetModel()`.
### Deprecated
- Deprecated `FieldDescription::getTargetEntity()` in favor of `FieldDescription::getTargetModel()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
