### PR TITLE
Add more tests

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\DatagridBuilder
+
+Changed constructor's first parameter typehint from `Symfony\Component\Form\FormFactory` to
+`Symfony\Component\Form\FormFactoryInterface`.
+
 ### Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager
 
 Deprecated `camelize()` method.

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/phpunit-bridge": "^5.0"
     },
     "suggest": {

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -23,14 +23,23 @@ use Sonata\AdminBundle\Filter\FilterFactoryInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class DatagridBuilder implements DatagridBuilderInterface
 {
+    /**
+     * @var FilterFactoryInterface
+     */
     protected $filterFactory;
 
+    /**
+     * @var FormFactoryInterface
+     */
     protected $formFactory;
 
+    /**
+     * @var TypeGuesserInterface
+     */
     protected $guesser;
 
     /**
@@ -43,7 +52,7 @@ class DatagridBuilder implements DatagridBuilderInterface
     /**
      * @param bool $csrfTokenEnabled
      */
-    public function __construct(FormFactory $formFactory, FilterFactoryInterface $filterFactory, TypeGuesserInterface $guesser, $csrfTokenEnabled = true)
+    public function __construct(FormFactoryInterface $formFactory, FilterFactoryInterface $filterFactory, TypeGuesserInterface $guesser, $csrfTokenEnabled = true)
     {
         $this->formFactory = $formFactory;
         $this->filterFactory = $filterFactory;

--- a/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
@@ -22,33 +22,36 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AddGuesserCompilerPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container)
     {
-        // ListBuilder
-        $definition = $container->getDefinition('sonata.admin.guesser.doctrine_mongodb_list_chain');
-        $services = [];
-        foreach ($container->findTaggedServiceIds('sonata.admin.guesser.doctrine_mongodb_list') as $id => $attributes) {
-            $services[] = new Reference($id);
+        $this->addGuessersToBuilder(
+            $container,
+            'sonata.admin.guesser.doctrine_mongodb_list_chain',
+            'sonata.admin.guesser.doctrine_mongodb_list'
+        );
+
+        $this->addGuessersToBuilder(
+            $container,
+            'sonata.admin.guesser.doctrine_mongodb_datagrid_chain',
+            'sonata.admin.guesser.doctrine_mongodb_datagrid'
+        );
+
+        $this->addGuessersToBuilder(
+            $container,
+            'sonata.admin.guesser.doctrine_mongodb_show_chain',
+            'sonata.admin.guesser.doctrine_mongodb_show'
+        );
+    }
+
+    private function addGuessersToBuilder(ContainerBuilder $container, string $builderDefinitionId, string $guessersTag): void
+    {
+        if (!$container->hasDefinition($builderDefinitionId)) {
+            return;
         }
 
-        $definition->replaceArgument(0, $services);
-
-        // DatagridBuilder
-        $definition = $container->getDefinition('sonata.admin.guesser.doctrine_mongodb_datagrid_chain');
+        $definition = $container->getDefinition($builderDefinitionId);
         $services = [];
-        foreach ($container->findTaggedServiceIds('sonata.admin.guesser.doctrine_mongodb_datagrid') as $id => $attributes) {
-            $services[] = new Reference($id);
-        }
-
-        $definition->replaceArgument(0, $services);
-
-        // ShowBuilder
-        $definition = $container->getDefinition('sonata.admin.guesser.doctrine_mongodb_show_chain');
-        $services = [];
-        foreach ($container->findTaggedServiceIds('sonata.admin.guesser.doctrine_mongodb_show') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds($guessersTag) as $id => $attributes) {
             $services[] = new Reference($id);
         }
 

--- a/src/DependencyInjection/SonataDoctrineMongoDBAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrineMongoDBAdminExtension.php
@@ -25,10 +25,6 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
  */
 class SonataDoctrineMongoDBAdminExtension extends AbstractSonataAdminExtension
 {
-    /**
-     * @param array            $configs   An array of configuration settings
-     * @param ContainerBuilder $container A ContainerBuilder instance
-     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configs = $this->fixTemplatesConfiguration($configs, $container);
@@ -41,8 +37,6 @@ class SonataDoctrineMongoDBAdminExtension extends AbstractSonataAdminExtension
         $configuration = new Configuration();
         $processor = new Processor();
         $config = $processor->processConfiguration($configuration, $configs);
-
-        $pool = $container->getDefinition('sonata.admin.manager.doctrine_mongodb');
 
         $container->setParameter('sonata_doctrine_mongodb_admin.templates', $config['templates']);
 

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -34,10 +34,6 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
-/**
- * @author Sullivan Senechal <soullivaneuh@gmail.com>
- * @author Marko Kunic <kunicmarko20@gmail.com>
- */
 final class DatagridBuilderTest extends TestCase
 {
     /**

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy;
+use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineMongoDBAdminBundle\Builder\DatagridBuilder;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class DatagridBuilderTest extends TestCase
+{
+    /**
+     * @var DatagridBuilder
+     */
+    private $datagridBuilder;
+
+    /**
+     * @var MockObject&TypeGuesserInterface
+     */
+    private $typeGuesser;
+
+    /**
+     * @var MockObject&FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var MockObject&FilterFactoryInterface
+     */
+    private $filterFactory;
+
+    /**
+     * @var MockObject&AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var MockObject&ModelManager
+     */
+    private $modelManager;
+
+    protected function setUp(): void
+    {
+        $this->formFactory = $this->createStub(FormFactoryInterface::class);
+        $this->filterFactory = $this->createStub(FilterFactoryInterface::class);
+        $this->typeGuesser = $this->createStub(TypeGuesserInterface::class);
+
+        $this->datagridBuilder = new DatagridBuilder(
+            $this->formFactory,
+            $this->filterFactory,
+            $this->typeGuesser
+        );
+
+        $this->admin = $this->createMock(AdminInterface::class);
+        $this->modelManager = $this->createMock(ModelManager::class);
+
+        $this->admin
+            ->method('getClass')
+            ->willReturn('FakeClass');
+        $this->admin
+            ->method('getModelManager')
+            ->willReturn($this->modelManager);
+    }
+
+    public function testGetBaseDatagrid(): void
+    {
+        $proxyQuery = $this->createStub(ProxyQueryInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionCollection::class);
+        $formBuilder = $this->createStub(FormBuilderInterface::class);
+
+        $this->admin->method('createQuery')->willReturn($proxyQuery);
+        $this->admin->method('getList')->willReturn($fieldDescription);
+
+        $this->modelManager->method('getIdentifierFieldNames')->willReturn(['id']);
+
+        $this->formFactory->method('createNamedBuilder')->willReturn($formBuilder);
+
+        $this->assertInstanceOf(
+            Datagrid::class,
+            $datagrid = $this->datagridBuilder->getBaseDatagrid($this->admin)
+        );
+        $this->assertInstanceOf(Pager::class, $datagrid->getPager());
+    }
+
+    public function testFixFieldDescription(): void
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('test');
+        $fieldDescription->setMappingType(ClassMetadata::ONE);
+
+        $this->admin
+            ->expects($this->once())
+            ->method('attachAdminClass');
+
+        $this->modelManager->method('hasMetadata')->willReturn(true);
+
+        $this->modelManager
+            ->expects($this->once())
+            ->method('getParentMetadataForProperty')
+            ->willReturn([$classMetadata, 'someField', $parentAssociationMapping = []]);
+
+        $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
+    }
+
+    public function testAddFilterNoType(): void
+    {
+        $this->admin
+            ->expects($this->once())
+            ->method('addFilterFieldDescription');
+
+        $datagrid = $this->createMock(DatagridInterface::class);
+        $guessType = new TypeGuess(ModelFilter::class, [
+            'name' => 'value',
+        ], Guess::VERY_HIGH_CONFIDENCE);
+
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('test');
+
+        $this->typeGuesser->method('guessType')->willReturn($guessType);
+
+        $this->modelManager
+            ->expects($this->once())
+            ->method('hasMetadata')->willReturn(false);
+
+        $this->admin->method('getCode')->willReturn('someFakeCode');
+
+        $this->filterFactory->method('create')->willReturn(new ModelFilter());
+
+        $this->admin->method('getLabelTranslatorStrategy')->willReturn(new FormLabelTranslatorStrategy());
+
+        $datagrid
+            ->expects($this->once())
+            ->method('addFilter')
+            ->with($this->isInstanceOf(ModelFilter::class));
+
+        $this->datagridBuilder->addFilter(
+            $datagrid,
+            null,
+            $fieldDescription,
+            $this->admin
+        );
+    }
+}

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -26,9 +26,6 @@ use Sonata\DoctrineMongoDBAdminBundle\Builder\ShowBuilder;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\Guess\TypeGuess;
 
-/**
- * @author Marko Kunic <kunicmarko20@gmail.com>
- */
 final class ShowBuilderTest extends TestCase
 {
     /**

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineMongoDBAdminBundle\Builder\ShowBuilder;
+use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class ShowBuilderTest extends TestCase
+{
+    /**
+     * @var Stub&TypeGuesserInterface
+     */
+    private $guesser;
+
+    /**
+     * @var ShowBuilder
+     */
+    private $showBuilder;
+
+    /**
+     * @var MockObject&AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var Stub&ModelManager
+     */
+    private $modelManager;
+
+    protected function setUp(): void
+    {
+        $this->guesser = $this->createStub(TypeGuesserInterface::class);
+
+        $this->showBuilder = new ShowBuilder(
+            $this->guesser,
+            [
+                'fakeTemplate' => 'fake',
+                TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+                TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+            ]
+        );
+
+        $this->admin = $this->createMock(AdminInterface::class);
+        $this->modelManager = $this->createStub(ModelManager::class);
+
+        $this->admin->method('getClass')->willReturn('FakeClass');
+        $this->admin->method('getModelManager')->willReturn($this->modelManager);
+    }
+
+    public function testGetBaseList(): void
+    {
+        $this->assertInstanceOf(FieldDescriptionCollection::class, $this->showBuilder->getBaseList());
+    }
+
+    public function testAddFieldNoType(): void
+    {
+        $typeGuess = $this->createStub(TypeGuess::class);
+
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('FakeName');
+        $fieldDescription->setMappingType(ClassMetadata::ONE);
+
+        $this->admin->expects($this->once())->method('attachAdminClass');
+        $this->admin->expects($this->once())->method('addShowFieldDescription');
+
+        $typeGuess->method('getType')->willReturn('fakeType');
+
+        $this->guesser->method('guessType')->willReturn($typeGuess);
+
+        $this->modelManager->method('hasMetadata')->willReturn(false);
+
+        $this->showBuilder->addField(
+            new FieldDescriptionCollection(),
+            null,
+            $fieldDescription,
+            $this->admin
+        );
+    }
+
+    public function testAddFieldWithType(): void
+    {
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('FakeName');
+
+        $this->admin->expects($this->once())->method('addShowFieldDescription');
+
+        $this->modelManager->method('hasMetadata')->willReturn(false);
+
+        $this->showBuilder->addField(
+            new FieldDescriptionCollection(),
+            'someType',
+            $fieldDescription,
+            $this->admin
+        );
+    }
+
+    /**
+     * @dataProvider fixFieldDescriptionData
+     */
+    public function testFixFieldDescription(string $type, string $mappingType, string $template): void
+    {
+        $classMetadata = $this->createStub(ClassMetadata::class);
+
+        $fieldDescription = new FieldDescription();
+        $fieldDescription->setName('FakeName');
+        $fieldDescription->setType($type);
+        $fieldDescription->setMappingType($mappingType);
+
+        $this->admin->expects($this->once())->method('attachAdminClass');
+
+        $this->modelManager->method('hasMetadata')->willReturn(true);
+
+        $this->modelManager->method('getParentMetadataForProperty')
+            ->willReturn([$classMetadata, 2, $parentAssociationMapping = []]);
+
+        $classMetadata->fieldMappings = [2 => []];
+
+        $classMetadata->associationMappings = [2 => ['fieldName' => 'fakeField']];
+
+        $this->showBuilder->fixFieldDescription($this->admin, $fieldDescription);
+
+        $this->assertSame($template, $fieldDescription->getTemplate());
+    }
+
+    public function fixFieldDescriptionData(): iterable
+    {
+        return [
+            'one' => [
+                TemplateRegistry::TYPE_MANY_TO_ONE,
+                ClassMetadata::ONE,
+                '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+            ],
+            'many' => [
+                TemplateRegistry::TYPE_MANY_TO_MANY,
+                ClassMetadata::MANY,
+                '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+            ],
+        ];
+    }
+
+    public function testFixFieldDescriptionException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->showBuilder->fixFieldDescription($this->admin, new FieldDescription());
+    }
+}

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -40,6 +40,8 @@ final class ProxyQueryTest extends TestCase
             ->with(0);
 
         $proxyQuery->setMaxResults(null);
+
+        $this->assertNull($proxyQuery->getMaxResults());
     }
 
     public function testSetSkipToZeroWhenResettingFirstResult(): void
@@ -52,5 +54,24 @@ final class ProxyQueryTest extends TestCase
             ->with(0);
 
         $proxyQuery->setFirstResult(null);
+
+        $this->assertNull($proxyQuery->getFirstResult());
+    }
+
+    public function testSorting(): void
+    {
+        $proxyQuery = new ProxyQuery($this->queryBuilder);
+        $proxyQuery->setSortBy([], ['fieldName' => 'name']);
+        $proxyQuery->setSortOrder('ASC');
+
+        $this->assertSame(
+            'name',
+            $proxyQuery->getSortBy()
+        );
+
+        $this->assertSame(
+            'ASC',
+            $proxyQuery->getSortOrder()
+        );
     }
 }

--- a/tests/DependencyInjection/Compiler/AddGuesserCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddGuesserCompilerPassTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AddGuesserCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    /** @dataProvider getBuilders */
+    public function testAddsGuessers(string $builderServiceId, string $guesserTag): void
+    {
+        $builderService = new Definition(null, [[]]);
+        $this->setDefinition($builderServiceId, $builderService);
+
+        $builderGuesserService = new Definition();
+        $builderGuesserService->addTag($guesserTag);
+        $this->setDefinition('builder_guesser_id', $builderGuesserService);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            $builderServiceId,
+            0,
+            [
+                new Reference('builder_guesser_id'),
+            ]
+        );
+    }
+
+    public function getBuilders(): array
+    {
+        return [
+          'list_builder' => [
+              'sonata.admin.guesser.doctrine_mongodb_list_chain',
+              'sonata.admin.guesser.doctrine_mongodb_list',
+          ],
+            'datagrid_builder' => [
+              'sonata.admin.guesser.doctrine_mongodb_datagrid_chain',
+              'sonata.admin.guesser.doctrine_mongodb_datagrid',
+          ], 'show_builder' => [
+              'sonata.admin.guesser.doctrine_mongodb_show_chain',
+              'sonata.admin.guesser.doctrine_mongodb_show',
+          ],
+        ];
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddGuesserCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class AddTemplatesCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testSetThemes(): void
+    {
+        $adminServiceId = 'admin_id';
+        $adminService = new Definition();
+        $adminService->addTag('sonata.admin', ['manager_type' => 'doctrine_mongodb']);
+        $this->setDefinition($adminServiceId, $adminService);
+
+        $adminServiceNotManagedId = 'admin_not_managed_id';
+        $adminServiceNotManaged = new Definition();
+        $adminServiceNotManaged->addTag('sonata.admin', ['manager_type' => 'type']);
+        $this->setDefinition($adminServiceNotManagedId, $adminServiceNotManaged);
+
+        $formTemplates = [
+            'form.html.twig',
+        ];
+        $filterTemplates = [
+            'filter.html.twig',
+        ];
+        $templates = [
+            'form' => $formTemplates,
+            'filter' => $filterTemplates,
+        ];
+
+        $this->setParameter('sonata_doctrine_mongodb_admin.templates', $templates);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            $adminServiceId,
+            'setFormTheme',
+            [
+                $formTemplates,
+            ]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            $adminServiceId,
+            'setFilterTheme',
+            [
+                $filterTemplates,
+            ]
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddTemplatesCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Configuration;
+
+class ConfigurationTest extends TestCase
+{
+    use ConfigurationTestCaseTrait;
+
+    public function testDefaultOptions(): void
+    {
+        $this->assertProcessedConfigurationEquals([], [
+            'templates' => [
+                'form' => [
+                    '@SonataDoctrineMongoDBAdmin/Form/form_admin_fields.html.twig',
+                ],
+                'filter' => [
+                    '@SonataDoctrineMongoDBAdmin/Form/filter_admin_fields.html.twig',
+                ],
+            ],
+        ]);
+    }
+
+    public function testCustomTemplates(): void
+    {
+        $this->assertProcessedConfigurationEquals([[
+            'templates' => [
+                'form' => ['form.twig.html', 'form_extra.twig.html'],
+                'filter' => ['filter.twig.html'],
+                'types' => [
+                    'list' => [
+                        'array' => 'list_array.twig.html',
+                    ],
+                    'show' => [
+                        'array' => 'show_array.twig.html',
+                    ],
+                ],
+            ],
+        ]], [
+            'templates' => [
+                'form' => ['form.twig.html', 'form_extra.twig.html'],
+                'filter' => ['filter.twig.html'],
+                'types' => [
+                    'list' => [
+                        'array' => 'list_array.twig.html',
+                    ],
+                    'show' => [
+                        'array' => 'show_array.twig.html',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testTemplateTypesWithInvalidValues(): void
+    {
+        $this->assertConfigurationIsInvalid(
+            [[
+                'templates' => [
+                    'types' => [
+                        'edit' => [],
+                    ],
+                ],
+            ]],
+            'edit'
+        );
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return new Configuration();
+    }
+}

--- a/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\SonataDoctrineMongoDBAdminExtension;
+
+final class SonataDoctrineMongoDBAdminExtensionTest extends AbstractExtensionTestCase
+{
+    public function testEntityManagerSetFactory(): void
+    {
+        $this->container->setParameter('kernel.bundles', []);
+        $this->load();
+
+        $this->assertContainerBuilderHasService('sonata.admin.manager.doctrine_mongodb');
+        $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_form');
+        $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_list');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list_filter');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list_chain');
+        $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_show');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_show');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_show_chain');
+        $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_datagrid');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_datagrid');
+        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_datagrid_chain');
+
+        $this->assertContainerBuilderHasService('sonata.admin.manager.doctrine_mongodb');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.boolean');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.callback');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.choice');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.model');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.string');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.number');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.date');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.datetime');
+
+        $this->assertContainerBuilderHasService('sonata.admin.manipulator.acl.object.doctrine_mongodb');
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataDoctrineMongoDBAdminExtension(),
+        ];
+    }
+}

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Guesser;
+
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\MappingException;
+use Doctrine\ODM\MongoDB\Types\Type;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineMongoDBAdminBundle\Guesser\TypeGuesser;
+use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Symfony\Component\Form\Guess\Guess;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+final class TypeGuesserTest extends TestCase
+{
+    /**
+     * @var Stub&ModelManager
+     */
+    private $modelManager;
+
+    /**
+     * @var TypeGuesser
+     */
+    private $guesser;
+
+    protected function setUp(): void
+    {
+        $this->modelManager = $this->createStub(ModelManager::class);
+        $this->guesser = new TypeGuesser();
+    }
+
+    public function testGuessTypeNoMetadata(): void
+    {
+        $class = 'FakeClass';
+        $property = 'fakeProperty';
+        $this->modelManager
+            ->method('getParentMetadataForProperty')
+            ->with($class, $property)
+            ->willThrowException(new MappingException());
+
+        $result = $this->guesser->guessType($class, $property, $this->modelManager);
+
+        $this->assertSame('text', $result->getType());
+        $this->assertSame(Guess::LOW_CONFIDENCE, $result->getConfidence());
+    }
+
+    /**
+     * @dataProvider associationData
+     */
+    public function testGuessTypeWithAssociation(string $mappingType, string $type): void
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+
+        $class = 'FakeClass';
+        $property = 'fakeProperty';
+
+        $classMetadata
+            ->method('hasAssociation')
+            ->with($property)
+            ->willReturn(true);
+
+        $classMetadata->fieldMappings = [$property => ['type' => $mappingType]];
+
+        $this->modelManager
+            ->method('getParentMetadataForProperty')
+            ->with($class, $property)
+            ->willReturn([
+                $classMetadata,
+                $property,
+                'notUsed',
+            ]);
+
+        $result = $this->guesser->guessType($class, $property, $this->modelManager);
+
+        $this->assertSame($type, $result->getType());
+        $this->assertSame(Guess::HIGH_CONFIDENCE, $result->getConfidence());
+    }
+
+    public function associationData(): array
+    {
+        return [
+            'many-to-one' => [
+                ClassMetadata::ONE,
+                'mongo_one',
+            ],
+            'one-to-many' => [
+                ClassMetadata::MANY,
+                'mongo_many',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider noAssociationData
+     */
+    public function testGuessTypeNoAssociation(string $type, string $resultType, int $confidence): void
+    {
+        $classMetadata = $this->createMock(ClassMetadata::class);
+
+        $class = 'FakeClass';
+        $property = 'fakeProperty';
+
+        $classMetadata
+            ->method('hasAssociation')
+            ->with($property)
+            ->willReturn(false);
+
+        $classMetadata
+            ->method('getTypeOfField')
+            ->with($property)
+            ->willReturn($type);
+
+        $this->modelManager
+            ->method('getParentMetadataForProperty')
+            ->with($class, $property)
+            ->willReturn([
+                $classMetadata,
+                $property,
+                'notUsed',
+            ]);
+
+        $result = $this->guesser->guessType($class, $property, $this->modelManager);
+
+        $this->assertSame($resultType, $result->getType());
+        $this->assertSame($confidence, $result->getConfidence());
+    }
+
+    public function noAssociationData(): array
+    {
+        return [
+            'collection' => [
+                Type::COLLECTION,
+                'array',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'hash' => [
+                Type::HASH,
+                'array',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'bool' => [
+                Type::BOOL,
+                'boolean',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'timestamp' => [
+                Type::TIMESTAMP,
+                'datetime',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'datetime_immutable' => [
+                Type::DATE_IMMUTABLE,
+                'date',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'date' => [
+                Type::DATE,
+                'date',
+                Guess::HIGH_CONFIDENCE,
+            ],
+            'float' => [
+                Type::FLOAT,
+                'number',
+                Guess::MEDIUM_CONFIDENCE,
+            ],
+            'integer' => [
+                Type::INT,
+                'integer',
+                Guess::MEDIUM_CONFIDENCE,
+            ],
+            'string' => [
+                Type::STRING,
+                'text',
+                Guess::MEDIUM_CONFIDENCE,
+            ],
+            'somefake' => [
+                'somefake',
+                'text',
+                Guess::LOW_CONFIDENCE,
+            ],
+        ];
+    }
+}

--- a/tests/SonataDoctrineMongoDBAdminBundleTest.php
+++ b/tests/SonataDoctrineMongoDBAdminBundleTest.php
@@ -19,9 +19,6 @@ use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddTemplatesC
 use Sonata\DoctrineMongoDBAdminBundle\SonataDoctrineMongoDBAdminBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-/**
- * @author Marko Kunic <kunicmarko20@gmail.com>
- */
 class SonataDoctrineMongoDBAdminBundleTest extends TestCase
 {
     public function testBuild(): void

--- a/tests/SonataDoctrineMongoDBAdminBundleTest.php
+++ b/tests/SonataDoctrineMongoDBAdminBundleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
+use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Sonata\DoctrineMongoDBAdminBundle\SonataDoctrineMongoDBAdminBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Marko Kunic <kunicmarko20@gmail.com>
+ */
+class SonataDoctrineMongoDBAdminBundleTest extends TestCase
+{
+    public function testBuild(): void
+    {
+        $containerBuilder = $this->createMock(ContainerBuilder::class);
+
+        $containerBuilder
+            ->expects($this->at(0))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf(AddGuesserCompilerPass::class));
+
+        $containerBuilder
+            ->expects($this->at(1))
+            ->method('addCompilerPass')
+            ->with($this->isInstanceOf(AddTemplatesCompilerPass::class));
+
+        $bundle = new SonataDoctrineMongoDBAdminBundle();
+        $bundle->build($containerBuilder);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Adding some more tests, some of them from the SonataDoctrineORMBundle.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Changed
- Changed `DatagridBuilder` constructor's first parameter typehint from `Symfony\Component\Form\FormFactory` to
`Symfony\Component\Form\FormFactoryInterface`.
```

~Not sure if a changelog is needed for the change from `FormFactory` to `FormFactoryInterface`.~