### PR TITLE
Revert variable name change

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -98,7 +98,9 @@ class DatagridBuilder implements DatagridBuilderInterface
         if (null === $type) {
             $guessType = $this->guesser->guessType($admin->getClass(), $fieldDescription->getName(), $admin->getModelManager());
 
-            $fieldDescription->setType($guessType->getType());
+            $type = $guessType->getType();
+
+            $fieldDescription->setType($type);
 
             $options = $guessType->getOptions();
 

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -69,7 +69,7 @@ final class DatagridBuilderTest extends TestCase
     protected function setUp(): void
     {
         $this->formFactory = $this->createStub(FormFactoryInterface::class);
-        $this->filterFactory = $this->createStub(FilterFactoryInterface::class);
+        $this->filterFactory = $this->createMock(FilterFactoryInterface::class);
         $this->typeGuesser = $this->createStub(TypeGuesserInterface::class);
 
         $this->datagridBuilder = new DatagridBuilder(
@@ -161,6 +161,11 @@ final class DatagridBuilderTest extends TestCase
             ->expects($this->once())
             ->method('addFilter')
             ->with($this->isInstanceOf(ModelFilter::class));
+
+        $this->filterFactory
+            ->expects($this->once())
+            ->method('create')
+            ->with('test', ModelFilter::class);
 
         $this->datagridBuilder->addFilter(
             $datagrid,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I made a mistake inlining the variable in https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/381/files#diff-eeb9e64780aabe9b2d7d6de3f0522447R101 because I didn't realise that it was used afterwards, now it's covered by the tests.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

I guess a changelog is not needed since there is no release since that commit.
