### PR TITLE
Remove references to deprecated help option

### DIFF
--- a/docs/reference/form_field_definition.rst
+++ b/docs/reference/form_field_definition.rst
@@ -23,6 +23,7 @@ Example
             $formMapper
                 ->add('author', ModelType::class, [], ['edit' => 'list'])
                 ->add('enabled')
+                // you can define help messages using Symfony help option
                 ->add('title', null, ['help' => 'help_post_title'])
                 ->add('abstract', null, ['required' => false])
                 ->add('content');

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -144,14 +144,6 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame($adminMock, $field->getParent());
     }
 
-    public function testGetHelp(): void
-    {
-        $field = new FieldDescription();
-        $field->setHelp('help message');
-
-        $this->assertSame($field->getHelp(), 'help message');
-    }
-
     public function testGetAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);


### PR DESCRIPTION
Those methods are from `Sonata\AdminBundle\Admin\BaseFieldDescription`, we shouldn't test them here.