### PR TITLE
Allow twig 3 and symfony/property-access 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,15 +36,15 @@
         "symfony/doctrine-bridge": "^4.4",
         "symfony/form": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/property-access": "^4.4",
-        "twig/twig": "^2.6"
+        "symfony/property-access": "^4.4 || ^5.1",
+        "twig/twig": "^2.6 || ^3.0"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.1.1"
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Allows usage of PHP 7"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6299

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for symfony/options-resolver:^5.1
- Added support for twig 3.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
