### PR TITLE
Make tests using ClassMetada more robust

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^1.10",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/phpunit-bridge": "^5.1.1"
     },

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Builder;
 
+use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -29,7 +31,7 @@ use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\DatagridBuilder;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\SimpleAnnotationDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentWithReferences;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Guess\Guess;
@@ -112,11 +114,7 @@ final class DatagridBuilderTest extends TestCase
 
     public function testFixFieldDescription(): void
     {
-        $classMetadata = new ClassMetadata(SimpleAnnotationDocument::class);
-        $classMetadata->mapField([
-            'fieldName' => 'name',
-            'type' => 'string',
-        ]);
+        $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('name');
@@ -136,10 +134,7 @@ final class DatagridBuilderTest extends TestCase
 
     public function testFixFieldDescriptionWithAssociationMapping(): void
     {
-        $classMetadata = new ClassMetadata(SimpleAnnotationDocument::class);
-        $classMetadata->mapOneEmbedded([
-            'fieldName' => 'associatedDocument',
-        ]);
+        $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('associatedDocument');
@@ -239,5 +234,16 @@ final class DatagridBuilderTest extends TestCase
         );
 
         $this->assertSame(ModelFilter::class, $fieldDescription->getType());
+    }
+
+    private function getMetadataForDocumentWithAnnotations(string $class): ClassMetadata
+    {
+        $classMetadata = new ClassMetadata($class);
+        $reader = new AnnotationReader();
+
+        $annotationDriver = new AnnotationDriver($reader);
+        $annotationDriver->loadMetadataForClass($class, $classMetadata);
+
+        return $classMetadata;
     }
 }

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -19,7 +19,7 @@ use Doctrine\ODM\MongoDB\Query\Builder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\SimpleAnnotationDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentWithReferences;
 
 final class ProxyQueryTest extends TestCase
 {
@@ -42,7 +42,7 @@ final class ProxyQueryTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->dm->createQueryBuilder(SimpleAnnotationDocument::class)
+        $this->dm->createQueryBuilder(DocumentWithReferences::class)
             ->remove()
             ->getQuery()
             ->execute();
@@ -102,7 +102,7 @@ final class ProxyQueryTest extends TestCase
      */
     public function testExecuteWithParameters(array $parameters, ?int $hydrationMode): void
     {
-        $queryBuilder = $this->dm->createQueryBuilder(SimpleAnnotationDocument::class);
+        $queryBuilder = $this->dm->createQueryBuilder(DocumentWithReferences::class);
 
         $proxyQuery = new ProxyQuery($queryBuilder);
 
@@ -122,14 +122,14 @@ final class ProxyQueryTest extends TestCase
 
     public function testExecuteAllowsSorting(): void
     {
-        $documentA = new SimpleAnnotationDocument('A');
-        $documentB = new SimpleAnnotationDocument('B');
+        $documentA = new DocumentWithReferences('A');
+        $documentB = new DocumentWithReferences('B');
 
         $this->dm->persist($documentA);
         $this->dm->persist($documentB);
         $this->dm->flush();
 
-        $queryBuilder = $this->dm->createQueryBuilder(SimpleAnnotationDocument::class);
+        $queryBuilder = $this->dm->createQueryBuilder(DocumentWithReferences::class);
         $queryBuilder->select('name')->hydrate(false);
         $proxyQuery = new ProxyQuery($queryBuilder);
         $proxyQuery->setSortBy([], ['fieldName' => 'name']);

--- a/tests/Fixtures/Document/AssociatedDocument.php
+++ b/tests/Fixtures/Document/AssociatedDocument.php
@@ -13,9 +13,23 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
 class AssociatedDocument
 {
+    /**
+     * @ODM\Field(type="int")
+     * @var int
+     */
     private $plainField;
+
+    /**
+     * @ODM\EmbedOne(targetDocument=EmbeddedDocument::class)
+     * @var EmbeddedDocument
+     */
     private $embeddedDocument;
 
     public function __construct(int $plainField, EmbeddedDocument $embeddedDocument)

--- a/tests/Fixtures/Document/ContainerDocument.php
+++ b/tests/Fixtures/Document/ContainerDocument.php
@@ -13,10 +13,29 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
 class ContainerDocument
 {
-    private $plainField;
+    /**
+     * @ODM\Field(type="int")
+     * @var int
+     */
+    protected $plainField;
+
+    /**
+     * @ODM\ReferenceOne(targetDocument=AssociatedDocument::class)
+     * @var AssociatedDocument
+     */
     private $associatedDocument;
+
+    /**
+     * @ODM\EmbedOne(targetDocument=EmbeddedDocument::class)
+     * @var EmbeddedDocument
+     */
     private $embeddedDocument;
 
     public function __construct(AssociatedDocument $associatedDocument, EmbeddedDocument $embeddedDocument)

--- a/tests/Fixtures/Document/DocumentWithReferences.php
+++ b/tests/Fixtures/Document/DocumentWithReferences.php
@@ -16,7 +16,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 /** @ODM\Document */
-class SimpleAnnotationDocument
+class DocumentWithReferences
 {
     /** @ODM\Id */
     private $id;
@@ -35,7 +35,7 @@ class SimpleAnnotationDocument
     private $embeddedDocument;
 
     /**
-     * @ODM\ReferenceOne(targetDocument=SimpleDocument::class)
+     * @ODM\ReferenceOne(targetDocument=TestDocument::class)
      */
     private $referenceOne;
 

--- a/tests/Fixtures/Document/EmbeddedDocument.php
+++ b/tests/Fixtures/Document/EmbeddedDocument.php
@@ -13,10 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\EmbeddedDocument
+ */
 class EmbeddedDocument
 {
     /**
+     * @ODM\Field(type="bool")
      * @var bool
      */
-    protected $plainField;
+    private $plainField;
 }

--- a/tests/Fixtures/Document/SimpleDocumentWithPrivateSetter.php
+++ b/tests/Fixtures/Document/SimpleDocumentWithPrivateSetter.php
@@ -13,8 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 
-final class SimpleDocumentWithPrivateSetter
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class SimpleDocumentWithPrivateSetter
 {
+    /**
+     * @ODM\Field(type="int")
+     */
     private $schmeckles;
 
     public function __construct(int $schmeckles)

--- a/tests/Fixtures/Document/TestDocument.php
+++ b/tests/Fixtures/Document/TestDocument.php
@@ -13,29 +13,53 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
 
-class SimpleDocument
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class TestDocument
 {
+    /**
+     * @ODM\Field(type="bool")
+     * @var bool
+     */
     public $schwifty;
+
+    /**
+     * @ODM\Field(type="int")
+     * @var int
+     */
     private $schmeckles;
+
+    /**
+     * @ODM\Field(type="string")
+     * @var string
+     */
     private $multiWordProperty;
+
+    /**
+     * @ODM\Field(type="int")
+     * @var int
+     */
     private $plumbus;
 
-    public function getSchmeckles()
+    public function getSchmeckles(): int
     {
         return $this->schmeckles;
     }
 
-    public function setSchmeckles($value): void
+    public function setSchmeckles(int $value): void
     {
         $this->schmeckles = $value;
     }
 
-    public function getMultiWordProperty()
+    public function getMultiWordProperty(): string
     {
         return $this->multiWordProperty;
     }
 
-    public function setMultiWordProperty($value): void
+    public function setMultiWordProperty(string $value): void
     {
         $this->multiWordProperty = $value;
     }


### PR DESCRIPTION
Instead of manually mapping fields, now the mapping is created reading the document annotations.