### PR TITLE
Add ManagerRegistry to ObjectAclManipulator

### DIFF
--- a/tests/Fixtures/Document/DocumentForAcl.php
+++ b/tests/Fixtures/Document/DocumentForAcl.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @ODM\Document
+ */
+class DocumentForAcl
+{
+    /**
+     * @ODM\Id
+     * @var string
+     */
+    private $id;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/tests/Util/ObjectAclManipulatorTest.php
+++ b/tests/Util/ObjectAclManipulatorTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Util;
+
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
+use Sonata\AdminBundle\Security\Handler\NoopSecurityHandler;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentForAcl;
+use Sonata\DoctrineMongoDBAdminBundle\Util\ObjectAclManipulator;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Security\Acl\Model\AclInterface;
+
+class ObjectAclManipulatorTest extends TestCase
+{
+    /**
+     * @var DocumentManager
+     */
+    private $dm;
+
+    protected function setUp(): void
+    {
+        $this->dm = DocumentManager::create(null, $this->createConfiguration());
+    }
+
+    public function testFailsWithoutACLSecurityHandler(): void
+    {
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getSecurityHandler')
+            ->willReturn($this->createStub(NoopSecurityHandler::class));
+
+        $objectAclManipulator = new ObjectAclManipulator($this->createStub(ManagerRegistry::class));
+
+        $output = new BufferedOutput();
+
+        $objectAclManipulator->batchConfigureAcls($output, $admin);
+
+        self::assertStringContainsString('Admin class is not configured to use ACL', $output->fetch());
+    }
+
+    public function testBatchConfigureAcls(): void
+    {
+        $this->dm->persist(new DocumentForAcl());
+        $this->dm->flush();
+
+        $aclSecurityHandler = $this->createStub(AclSecurityHandlerInterface::class);
+        $aclSecurityHandler
+            ->method('findObjectAcls')
+            ->willReturn(new \SplObjectStorage());
+
+        $aclSecurityHandler
+            ->method('buildSecurityInformation')
+            ->willReturn([]);
+
+        $aclSecurityHandler
+            ->method('createAcl')
+            ->willReturn($this->createStub(AclInterface::class));
+
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getSecurityHandler')
+            ->willReturn($aclSecurityHandler);
+
+        $admin
+            ->method('getClass')
+            ->willReturn(DocumentForAcl::class);
+
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+
+        $admin
+            ->method('getModelManager')
+            ->willReturn($modelManager);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry
+            ->method('getManagerForClass')
+            ->willReturn($this->dm);
+
+        $objectAclManipulator = new ObjectAclManipulator($managerRegistry);
+
+        $output = new BufferedOutput();
+
+        $objectAclManipulator->batchConfigureAcls($output, $admin);
+
+        self::assertStringContainsString('[TOTAL] generated class ACEs for 1 objects (added 1, updated 0)', $output->fetch());
+
+        $this->dm->createQueryBuilder(DocumentForAcl::class)
+            ->remove()
+            ->getQuery()
+            ->execute();
+    }
+
+    private function createConfiguration(): Configuration
+    {
+        $config = new Configuration();
+
+        $directory = sys_get_temp_dir().'/mongodb';
+
+        $config->setProxyDir($directory);
+        $config->setProxyNamespace('Proxies');
+        $config->setHydratorDir($directory);
+        $config->setHydratorNamespace('Hydrators');
+        $config->setPersistentCollectionDir($directory);
+        $config->setPersistentCollectionNamespace('PersistentCollections');
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver());
+
+        return $config;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This adds ManagerRegistry to ObjectAclManipulator, so there is no need of calling `$admin->getModelManager()->getDocumentManager()` which does not exist in the interface.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate creating `ObjectAclManipulator` without passing a `ManagerRegistry` object.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
