### PR TITLE
Initialize field description mapping properties

### DIFF
--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -115,6 +115,7 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
 
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('name');
+        $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
         $this->modelManager->method('hasMetadata')->willReturn(true);
 
@@ -136,6 +137,8 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('associatedDocument');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
+        $fieldDescription->setFieldMapping($classMetadata->fieldMappings['associatedDocument']);
+        $fieldDescription->setAssociationMapping($classMetadata->associationMappings['associatedDocument']);
 
         $this->admin
             ->expects($this->once())

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -161,6 +161,7 @@ class FormContractorTest extends AbstractBuilderTestCase
         $fieldDescription = new FieldDescription();
         $fieldDescription->setMappingType(ClassMetadata::ONE);
         $fieldDescription->setName('name');
+        $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
 
@@ -181,6 +182,8 @@ class FormContractorTest extends AbstractBuilderTestCase
         $fieldDescription = new FieldDescription();
         $fieldDescription->setMappingType(ClassMetadata::ONE);
         $fieldDescription->setName('associatedDocument');
+        $fieldDescription->setFieldMapping($classMetadata->fieldMappings['associatedDocument']);
+        $fieldDescription->setAssociationMapping($classMetadata->associationMappings['associatedDocument']);
 
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
 

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -180,7 +180,10 @@ class ModelFilterTest extends TestCase
             'field_name' => 'field_name',
             'association_mapping' => [
                 'fieldName' => 'association_mapping',
-            ], 'field_mapping' => true,
+            ],
+            'field_mapping' => [
+                'fieldName' => 'association_mapping',
+            ],
         ]);
 
         $builder = new ProxyQuery($this->queryBuilder);
@@ -212,7 +215,10 @@ class ModelFilterTest extends TestCase
             ],
             'association_mapping' => [
                 'fieldName' => 'sub_sub_association_mapping',
-            ], 'field_mapping' => true,
+            ],
+            'field_mapping' => [
+                'fieldName' => 'sub_sub_association_mapping',
+            ],
         ]);
 
         $builder = new ProxyQuery($this->queryBuilder);


### PR DESCRIPTION
When a FieldDescription is instanciated, it adds some mapping information from ClassMetadata, now we do the same in tests.

https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/6d71c97710a4805a274f5773b31bc3d1fee3cf99/src/Model/ModelManager.php#L109-L140

These are things I'm finding when trying to use `sonata-project/admin-bundle` `4.x`.