### PR TITLE
Add missing mongodb_service argument to object acl manipulator

### DIFF
--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -13,14 +13,19 @@ declare(strict_types=1);
 
 use Sonata\DoctrineMongoDBAdminBundle\Util\ObjectAclManipulator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
 
         ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb.class', ObjectAclManipulator::class);
 
+    // Use "service" function for creating references to services when dropping support for Symfony 4.4
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb', '%sonata.admin.manipulator.acl.object.doctrine_mongodb.class%');
+        ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb', '%sonata.admin.manipulator.acl.object.doctrine_mongodb.class%')
+            ->args([
+                new ReferenceConfigurator('doctrine_mongodb'),
+            ]);
 };

--- a/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
@@ -47,6 +47,11 @@ final class SonataDoctrineMongoDBAdminExtensionTest extends AbstractExtensionTes
         $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.datetime');
 
         $this->assertContainerBuilderHasService('sonata.admin.manipulator.acl.object.doctrine_mongodb');
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.manipulator.acl.object.doctrine_mongodb',
+            0,
+            'doctrine_mongodb'
+        );
     }
 
     protected function getContainerExtensions(): array


### PR DESCRIPTION
It was missing in https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/414.

I am targeting this branch, because this is BC.