### PR TITLE
Drop support for doctrine/mongodb-odm 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,10 @@
     ],
     "require": {
         "php": "^7.2",
+        "ext-mongodb": "*",
         "doctrine/collections": "^1.6",
-        "doctrine/mongodb-odm": "^1.3 || ^2.1",
-        "doctrine/mongodb-odm-bundle": "^3.6 || ^4.0",
+        "doctrine/mongodb-odm": "^2.1",
+        "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
         "sonata-project/admin-bundle": "^3.75",
         "sonata-project/form-extensions": "^0.1 || ^1.4",

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -123,26 +123,17 @@ class ModelFilter extends Filter
     }
 
     /**
-     * Return \MongoId|ObjectId if $id is MongoId|ObjectId in string representation, otherwise custom string.
+     * Return ObjectId if $id is ObjectId in string representation, otherwise custom string.
      *
      * @param mixed $id
      *
-     * @return \MongoId|string|ObjectId
+     * @return string|ObjectId
      */
     protected static function fixIdentifier($id)
     {
-        // NEXT_MAJOR: Use only ObjectId when dropping support for doctrine/mongodb-odm 1.x
-        if (class_exists(ObjectId::class)) {
-            try {
-                return new ObjectId($id);
-            } catch (InvalidArgumentException $ex) {
-                return $id;
-            }
-        }
-
         try {
-            return new \MongoId($id);
-        } catch (\MongoException $ex) {
+            return new ObjectId($id);
+        } catch (InvalidArgumentException $ex) {
             return $id;
         }
     }

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -46,9 +46,9 @@ class StringFilter extends Filter
         if (ContainsOperatorType::TYPE_EQUAL === $data['type']) {
             $obj->field($field)->equals($data['value']);
         } elseif (ContainsOperatorType::TYPE_CONTAINS === $data['type']) {
-            $obj->field($field)->equals($this->getRegexExpression($data['value']));
+            $obj->field($field)->equals(new Regex($data['value'], 'i'));
         } elseif (ContainsOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
-            $obj->field($field)->not($this->getRegexExpression($data['value']));
+            $obj->field($field)->not(new Regex($data['value'], 'i'));
         }
 
         if (self::CONDITION_OR === $this->condition) {
@@ -73,19 +73,5 @@ class StringFilter extends Filter
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),
         ]];
-    }
-
-    /**
-     * NEXT_MAJOR: Use only Regex when dropping support for doctrine/mongodb-odm 1.x.
-     *
-     * @return Regex|\MongoRegex
-     */
-    private function getRegexExpression(string $pattern)
-    {
-        if (class_exists(Regex::class)) {
-            return new Regex($pattern, 'i');
-        }
-
-        return new \MongoRegex(sprintf('/%s/i', $pattern));
     }
 }

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -100,9 +100,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
                 return new TypeGuess(DateTimeFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case Type::DATE:
 
-            // NEXT_MAJOR: Use only the constant when dropping support for doctrine/mongodb-odm 1.3.
-            // case Type::DATE_IMMUTABLE:
-            case 'date_immutable':
+            case Type::DATE_IMMUTABLE:
                 $options['field_type'] = DateType::class;
 
                 return new TypeGuess(DateFilter::class, $options, Guess::HIGH_CONFIDENCE);

--- a/src/Guesser/TypeGuesser.php
+++ b/src/Guesser/TypeGuesser.php
@@ -79,9 +79,7 @@ class TypeGuesser extends AbstractTypeGuesser
             case Type::TIMESTAMP:
                 return new TypeGuess('datetime', [], Guess::HIGH_CONFIDENCE);
             case Type::DATE:
-            // NEXT_MAJOR: Use only the constant when dropping support for doctrine/mongodb-odm 1.3.
-            // case Type::DATE_IMMUTABLE:
-            case 'date_immutable':
+            case Type::DATE_IMMUTABLE:
                 return new TypeGuess('date', [], Guess::HIGH_CONFIDENCE);
             case 'decimal':
                 @trigger_error(

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -28,8 +28,7 @@ class DocumentStub
 
     public function __construct()
     {
-        // NEXT_MAJOR: Use only ObjectId when dropping support for doctrine/mongodb-odm 1.x
-        $this->id = class_exists(ObjectId::class) ? new ObjectId() : new MongoId();
+        $this->id = new ObjectId();
     }
 
     public function getId()
@@ -97,7 +96,7 @@ class ModelFilterTest extends TestCase
         $builder->getQueryBuilder()
             ->expects($this->once())
             ->method('in')
-            ->with([$this->getMongoIdentifier($oneDocument->getId()), $this->getMongoIdentifier($otherDocument->getId())])
+            ->with([new ObjectId($oneDocument->getId()), new ObjectId($otherDocument->getId())])
         ;
 
         $filter->filter($builder, 'alias', 'field', [
@@ -127,7 +126,7 @@ class ModelFilterTest extends TestCase
         $builder->getQueryBuilder()
             ->expects($this->once())
             ->method('equals')
-            ->with($this->getMongoIdentifier($document1->getId()))
+            ->with(new ObjectId($document1->getId()))
         ;
 
         $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => $document1]);
@@ -251,15 +250,5 @@ class ModelFilterTest extends TestCase
             [ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB, '.$id'],
             [ClassMetadata::REFERENCE_STORE_AS_DB_REF, '.$id'],
         ];
-    }
-
-    /**
-     * NEXT_MAJOR: Use only ObjectId when dropping support for doctrine/mongodb-odm 1.x.
-     *
-     * @return ObjectId|\MongoId
-     */
-    private function getMongoIdentifier(string $id)
-    {
-        return class_exists(ObjectId::class) ? new ObjectId($id) : new \MongoId($id);
     }
 }

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -50,7 +50,7 @@ class StringFilterTest extends FilterWithQueryBuilderTest
         $builder->getQueryBuilder()
             ->expects($this->exactly(2))
             ->method('equals')
-            ->with($this->getMongoRegex('asd'))
+            ->with(new Regex('asd', 'i'))
         ;
 
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_CONTAINS]);
@@ -68,7 +68,7 @@ class StringFilterTest extends FilterWithQueryBuilderTest
         $builder->getQueryBuilder()
             ->expects($this->once())
             ->method('not')
-            ->with($this->getMongoRegex('asd'))
+            ->with(new Regex('asd', 'i'))
         ;
 
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_NOT_CONTAINS]);
@@ -148,19 +148,5 @@ class StringFilterTest extends FilterWithQueryBuilderTest
         $builder->getQueryBuilder()->expects($this->never())->method('addOr');
         $filter->filter($builder, 'alias', 'field', ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_CONTAINS]);
         $this->assertTrue($filter->isActive());
-    }
-
-    /**
-     * NEXT_MAJOR: Use only Regex when dropping support for doctrine/mongodb-odm 1.x.
-     *
-     * @return Regex|\MongoRegex
-     */
-    private function getMongoRegex(string $pattern)
-    {
-        if (class_exists(Regex::class)) {
-            return new Regex($pattern, 'i');
-        }
-
-        return new \MongoRegex(sprintf('/%s/i', $pattern));
     }
 }

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -141,7 +141,7 @@ final class TypeGuesserTest extends TestCase
 
     public function noAssociationData(): array
     {
-        $noAssociationData = [
+        return [
             'collection' => [
                 Type::COLLECTION,
                 'array',
@@ -167,6 +167,11 @@ final class TypeGuesserTest extends TestCase
                 'date',
                 Guess::HIGH_CONFIDENCE,
             ],
+            'date_immutable' => [
+                Type::DATE_IMMUTABLE,
+                'date',
+                Guess::HIGH_CONFIDENCE,
+            ],
             'float' => [
                 Type::FLOAT,
                 'number',
@@ -188,16 +193,5 @@ final class TypeGuesserTest extends TestCase
                 Guess::LOW_CONFIDENCE,
             ],
         ];
-
-        // Remove the check and add the case to the "$noAssociationData" when dropping support of doctrine/mongodb-odm 1.x
-        if (\defined(sprintf('%s::DATE_IMMUTABLE', Type::class))) {
-            $noAssociationData['datetime_immutable'] = [
-                Type::DATE_IMMUTABLE,
-                'date',
-                Guess::HIGH_CONFIDENCE,
-            ];
-        }
-
-        return $noAssociationData;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/dev-kit/issues/1069

We are dropping support for doctrine/mongodb-odm <2.0, this allows us to not install `alcaeus/mongo-php-adapter` in GA for tests.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/sonata-doctrine-extensions/blob/1.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/sonata-doctrine-extensions/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove support for `doctrine/mongodb-odm` <2.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
