### PR TITLE
Add supportsQuery and deprecations

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -154,11 +154,21 @@ class ProxyQuery implements ProxyQueryInterface
         return $this->maxResults;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getUniqueParameterId()
     {
         // TODO: Implement getUniqueParameterId() method.
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function entityJoin(array $associationMappings)
     {
         // TODO: Implement entityJoin() method.

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -246,11 +246,29 @@ class ModelManager implements ModelManagerInterface
         return new ProxyQuery($repository->createQueryBuilder());
     }
 
+    public function supportsQuery(object $query): bool
+    {
+        return $query instanceof ProxyQuery || $query instanceof Builder;
+    }
+
     public function executeQuery($query)
     {
         if ($query instanceof Builder) {
             return $query->getQuery()->execute();
         }
+
+        if ($query instanceof ProxyQuery) {
+            return $query->execute();
+        }
+
+        // NEXT_MAJOR: Throw an InvalidArgumentException instead.
+        @trigger_error(sprintf(
+            'Passing other type than "%s" or %s as argument 1 for "%s()" is deprecated since'
+            .' sonata-project/doctrine-mongodb-admin-bundle 3.x and will throw an exception in 4.0.',
+            Builder::class,
+            ProxyQuery::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
 
         return $query->execute();
     }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -28,6 +28,7 @@ use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\Datagrid;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AbstractDocument;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AssociatedDocument;
@@ -408,6 +409,26 @@ final class ModelManagerTest extends TestCase
 
         $modelManager = new ModelManager($this->registry, $this->propertyAccessor);
         $modelManager->createQuery(TestDocument::class);
+    }
+
+    /**
+     * @dataProvider supportsQueryDataProvider
+     */
+    public function testSupportsQuery(bool $expected, object $object): void
+    {
+        $modelManager = new ModelManager($this->registry, $this->propertyAccessor);
+
+        $this->assertSame($expected, $modelManager->supportsQuery($object));
+    }
+
+    /**
+     * @phpstan-return iterable<array{bool, object}>
+     */
+    public function supportsQueryDataProvider(): iterable
+    {
+        yield [true, $this->createStub(ProxyQuery::class)];
+        yield [true, $this->createStub(Builder::class)];
+        yield [false, new \stdClass()];
     }
 
     private function createModelManagerForClass(string $class): ModelManager


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1113 and https://github.com/sonata-project/SonataAdminBundle/issues/6273

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ModelManager::supportsQuery()`.
### Deprecated
- Deprecated `ProxyQuery::getUniqueParameterId` and `ProxyQuery::entityJoin`.
- Deprecated calling `ModelManager::executeQuery` with anything but an instance of `Doctrine\ODM\MongoDB\Query\Builder` or `Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
