### PR TITLE
Add NEXT_MAJOR comments to remove alias parameter from filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.75",
+        "sonata-project/admin-bundle": "^3.78",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -36,6 +36,9 @@ abstract class AbstractDateFilter extends Filter
      */
     protected $time = false;
 
+    /**
+     * NEXT_MAJOR: Remove $alias parameter.
+     */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {
         //check data sanity

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -24,9 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 class BooleanFilter extends Filter
 {
     /**
-     * @param string $alias
-     * @param string $field
-     * @param mixed  $value
+     * NEXT_MAJOR: Remove $alias parameter.
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -24,11 +24,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 class CallbackFilter extends Filter
 {
     /**
-     * @param string $alias
-     * @param string $field
-     * @param string $value
-     *
-     * @throws \RuntimeException
+     * NEXT_MAJOR: Remove $alias parameter.
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {
@@ -39,6 +35,7 @@ class CallbackFilter extends Filter
             ));
         }
 
+        // NEXT_MAJOR: Remove $alias parameter.
         \call_user_func($this->getOption('callback'), $queryBuilder, $alias, $field, $value);
 
         if (\is_callable($this->getOption('active_callback'))) {

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -24,9 +24,7 @@ use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 class ChoiceFilter extends Filter
 {
     /**
-     * @param string $alias
-     * @param string $field
-     * @param mixed  $value
+     * NEXT_MAJOR: Remove $alias parameter.
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
+// NEXT MAJOR: Uncomment next line.
+// use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
 
 abstract class Filter extends BaseFilter
@@ -25,8 +27,12 @@ abstract class Filter extends BaseFilter
 
         $field = $this->getParentAssociationMappings() ? $this->getName() : $this->getFieldName();
 
+        // NEXT_MAJOR: Remove null argument.
         $this->filter($query, null, $field, $value);
     }
+
+    // NEXT_MAJOR: Uncomment this code.
+    // abstract protected function filter(ProxyQueryInterface $queryBuilder, string $field, $value);
 
     public function isActive()
     {

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -28,9 +28,7 @@ use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 class ModelFilter extends Filter
 {
     /**
-     * @param string $alias
-     * @param string $field
-     * @param mixed  $value
+     * NEXT_MAJOR: Remove $alias parameter.
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {
@@ -45,8 +43,10 @@ class ModelFilter extends Filter
         $field = $this->getIdentifierField($field);
 
         if (\is_array($value['value'])) {
+            // NEXT_MAJOR: Remove $alias argument.
             $this->handleMultiple($queryBuilder, $alias, $field, $value);
         } else {
+            // NEXT_MAJOR: Remove $alias argument.
             $this->handleScalar($queryBuilder, $alias, $field, $value);
         }
     }
@@ -75,6 +75,8 @@ class ModelFilter extends Filter
     }
 
     /**
+     * NEXT_MAJOR: Remove $alias parameter.
+     *
      * @param string $alias
      * @param string $field
      * @param array  $data
@@ -102,6 +104,8 @@ class ModelFilter extends Filter
     }
 
     /**
+     * NEXT_MAJOR: Remove $alias parameter.
+     *
      * @param string $alias
      * @param string $field
      * @param array  $data

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -30,6 +30,9 @@ class NumberFilter extends Filter
         NumberOperatorType::TYPE_LESS_THAN => 'lt',
     ];
 
+    /**
+     * NEXT_MAJOR: Remove $alias parameter.
+     */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {
         if (!$value || !\is_array($value) || !\array_key_exists('value', $value) || !is_numeric($value['value'])) {

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -24,8 +24,7 @@ use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 class StringFilter extends Filter
 {
     /**
-     * @param string $field
-     * @param array  $value
+     * NEXT_MAJOR: Remove $alias parameter.
      */
     public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value)
     {

--- a/tests/Filter/ChoiceFilterTest.php
+++ b/tests/Filter/ChoiceFilterTest.php
@@ -19,10 +19,14 @@ use Sonata\DoctrineMongoDBAdminBundle\Filter\ChoiceFilter;
 
 class ChoiceFilterTest extends FilterWithQueryBuilderTest
 {
-    public function testFilterEmpty(): void
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getNotApplicableValues
+     */
+    public function testFilterEmpty($value): void
     {
-        $filter = new ChoiceFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -31,17 +35,23 @@ class ChoiceFilterTest extends FilterWithQueryBuilderTest
             ->method('field')
         ;
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'all');
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->apply($builder, $value);
 
         $this->assertFalse($filter->isActive());
     }
 
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [null],
+            ['all'],
+            [[]],
+        ];
+    }
+
     public function testFilterArray(): void
     {
-        $filter = new ChoiceFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -51,15 +61,14 @@ class ChoiceFilterTest extends FilterWithQueryBuilderTest
             ->with(['1', '2'])
         ;
 
-        $filter->filter($builder, 'alias', 'field', ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => ['1', '2']]);
+        $filter->apply($builder, ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => ['1', '2']]);
 
         $this->assertTrue($filter->isActive());
     }
 
     public function testFilterScalar(): void
     {
-        $filter = new ChoiceFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -69,15 +78,14 @@ class ChoiceFilterTest extends FilterWithQueryBuilderTest
             ->with('1')
         ;
 
-        $filter->filter($builder, 'alias', 'field', ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => '1']);
+        $filter->apply($builder, ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => '1']);
 
         $this->assertTrue($filter->isActive());
     }
 
     public function testFilterZero(): void
     {
-        $filter = new ChoiceFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -87,8 +95,19 @@ class ChoiceFilterTest extends FilterWithQueryBuilderTest
             ->with('0')
         ;
 
-        $filter->filter($builder, 'alias', 'field', ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => 0]);
+        $filter->apply($builder, ['type' => ContainsOperatorType::TYPE_CONTAINS, 'value' => 0]);
 
         $this->assertTrue($filter->isActive());
+    }
+
+    private function createFilter(): ChoiceFilter
+    {
+        $filter = new ChoiceFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        return $filter;
     }
 }

--- a/tests/Filter/DateTimeFilterTest.php
+++ b/tests/Filter/DateTimeFilterTest.php
@@ -20,10 +20,14 @@ use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 final class DateTimeFilterTest extends FilterWithQueryBuilderTest
 {
-    public function testEmpty(): void
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getNotApplicableValues
+     */
+    public function testEmpty($value): void
     {
-        $filter = new DateTimeFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -32,11 +36,18 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
             ->method('field')
         ;
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', '');
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->apply($builder, $value);
 
         $this->assertFalse($filter->isActive());
+    }
+
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [null],
+            [''],
+            [[]],
+        ];
     }
 
     public function testGetType(): void
@@ -49,8 +60,7 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
      */
     public function testFilter(array $data, string $method): void
     {
-        $filter = new DateTimeFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -60,7 +70,7 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
             ->with($data['value'] ?? null)
         ;
 
-        $filter->filter($builder, 'alias', 'field', $data);
+        $filter->apply($builder, $data);
 
         $this->assertTrue($filter->isActive());
     }
@@ -77,5 +87,16 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
             [['type' => DateOperatorType::TYPE_NOT_NULL], 'notEqual'],
             [['value' => new \DateTime('now')], 'range'],
         ];
+    }
+
+    private function createFilter(): DateTimeFilter
+    {
+        $filter = new DateTimeFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        return $filter;
     }
 }

--- a/tests/Filter/FilterWithQueryBuilderTest.php
+++ b/tests/Filter/FilterWithQueryBuilderTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\TestCase;
 
 abstract class FilterWithQueryBuilderTest extends TestCase
 {
+    protected const DEFAULT_FIELD_NAME = 'field';
+
     private $queryBuilder;
     private $expr;
 
@@ -27,7 +29,7 @@ abstract class FilterWithQueryBuilderTest extends TestCase
         $this->queryBuilder = $this->createMock(Builder::class);
         $this->queryBuilder
             ->method('field')
-            ->with('field')
+            ->with(self::DEFAULT_FIELD_NAME)
             ->willReturnSelf()
         ;
         $this->expr = $this->createMock(Expr::class);

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -58,10 +58,18 @@ class ModelFilterTest extends TestCase
         return $fieldDescription;
     }
 
-    public function testFilterEmpty(): void
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getNotApplicableValues
+     */
+    public function testFilterEmpty($value): void
     {
         $filter = new ModelFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter->initialize('field_name', [
+            'field_name' => 'field',
+            'field_options' => ['class' => 'FooBar'],
+        ]);
 
         $builder = new ProxyQuery($this->queryBuilder);
 
@@ -70,16 +78,24 @@ class ModelFilterTest extends TestCase
             ->method('field')
         ;
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', []);
+        $filter->apply($builder, $value);
 
         $this->assertFalse($filter->isActive());
+    }
+
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [null],
+            [[]],
+        ];
     }
 
     public function testFilterArray(): void
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
+            'field_name' => 'field',
             'field_options' => [
                 'class' => 'FooBar',
             ],
@@ -106,7 +122,7 @@ class ModelFilterTest extends TestCase
             ->with([new ObjectId($oneDocument->getId()), new ObjectId($otherDocument->getId())])
         ;
 
-        $filter->filter($builder, 'alias', 'field', [
+        $filter->apply($builder, [
             'type' => EqualOperatorType::TYPE_EQUAL,
             'value' => [$oneDocument, $otherDocument],
         ]);
@@ -118,6 +134,7 @@ class ModelFilterTest extends TestCase
     {
         $filter = new ModelFilter();
         $filter->initialize('field_name', [
+            'field_name' => 'field',
             'field_options' => [
                 'class' => 'FooBar',
             ],
@@ -143,7 +160,7 @@ class ModelFilterTest extends TestCase
             ->with(new ObjectId($document1->getId()))
         ;
 
-        $filter->filter($builder, 'alias', 'field', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => $document1]);
+        $filter->apply($builder, ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => $document1]);
 
         $this->assertTrue($filter->isActive());
     }

--- a/tests/Filter/NumberFilterTest.php
+++ b/tests/Filter/NumberFilterTest.php
@@ -19,10 +19,14 @@ use Sonata\DoctrineMongoDBAdminBundle\Filter\NumberFilter;
 
 class NumberFilterTest extends FilterWithQueryBuilderTest
 {
-    public function testFilterEmpty(): void
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getNotApplicableValues
+     */
+    public function testFilterEmpty($value): void
     {
-        $filter = new NumberFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -31,16 +35,22 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
             ->method('field')
         ;
 
-        $filter->filter($builder, 'alias', 'field', null);
-        $filter->filter($builder, 'alias', 'field', 'asds');
+        $filter->apply($builder, $value);
 
         $this->assertFalse($filter->isActive());
     }
 
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [null],
+            ['scalar'],
+        ];
+    }
+
     public function testFilterInvalidOperator(): void
     {
-        $filter = new NumberFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -49,7 +59,7 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
             ->method('field')
         ;
 
-        $filter->filter($builder, 'alias', 'field', ['type' => 'foo']);
+        $filter->apply($builder, ['type' => 'foo']);
 
         $this->assertFalse($filter->isActive());
     }
@@ -59,8 +69,7 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
      */
     public function testFilter(array $data, string $method): void
     {
-        $filter = new NumberFilter();
-        $filter->initialize('field_name', ['field_options' => ['class' => 'FooBar']]);
+        $filter = $this->createFilter();
 
         $builder = new ProxyQuery($this->getQueryBuilder());
 
@@ -70,7 +79,7 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
             ->with($data['value'])
         ;
 
-        $filter->filter($builder, 'alias', 'field', $data);
+        $filter->apply($builder, $data);
 
         $this->assertTrue($filter->isActive());
     }
@@ -85,5 +94,16 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
             [['type' => NumberOperatorType::TYPE_LESS_THAN, 'value' => 42], 'lt'],
             [['value' => 42], 'equals'],
         ];
+    }
+
+    private function createFilter(): NumberFilter
+    {
+        $filter = new NumberFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+            'field_options' => ['class' => 'FooBar'],
+        ]);
+
+        return $filter;
     }
 }


### PR DESCRIPTION
Since sonata-project/admin-bundle 3.78, `FilterInterface::filter` was deprecated, this PR prepares filters to update to 4.0 by removing the "alias" argument and parameter.

It also rewrites tests to not call `FilterInterface::filter` but `FilterInterface::apply`.

I marked it as _pedantic_ since currently this change does not affect users, but let me know if I should change it.