### PR TITLE
Remove deprecations constructing FieldDescription

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.75",
+        "sonata-project/admin-bundle": "^3.78",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Admin/FieldDescription.php
+++ b/src/Admin/FieldDescription.php
@@ -20,11 +20,6 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
  */
 class FieldDescription extends BaseFieldDescription
 {
-    public function __construct()
-    {
-        $this->parentAssociationMappings = [];
-    }
-
     public function setAssociationMapping($associationMapping)
     {
         if (!\is_array($associationMapping)) {

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -125,9 +125,7 @@ class ModelManager implements ModelManagerInterface
 
         [$metadata, $propertyName, $parentAssociationMappings] = $this->getParentMetadataForProperty($class, $name);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName($name);
-        $fieldDescription->setOptions($options);
+        $fieldDescription = new FieldDescription($name, $options);
         $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
 
         /* @var ClassMetadata */

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -24,7 +24,7 @@ class FieldDescriptionTest extends TestCase
 {
     public function testOptions(): void
     {
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setOptions([
             'template' => 'foo',
             'type' => 'bar',
@@ -87,7 +87,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testAssociationMapping(): void
     {
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping([
             'type' => 'integer',
             'fieldName' => 'position',
@@ -112,7 +112,7 @@ class FieldDescriptionTest extends TestCase
 
     public function testSetName(): void
     {
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setName('New field description name');
 
         $this->assertSame($field->getName(), 'New field description name');
@@ -120,15 +120,14 @@ class FieldDescriptionTest extends TestCase
 
     public function testSetNameSetFieldNameToo(): void
     {
-        $field = new FieldDescription();
-        $field->setName('New field description name');
+        $field = new FieldDescription('New field description name');
 
         $this->assertSame($field->getFieldName(), 'New field description name');
     }
 
     public function testSetNameDoesNotSetFieldNameWhenSetBefore(): void
     {
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldName('field name');
         $field->setName('New field description name');
 
@@ -138,7 +137,7 @@ class FieldDescriptionTest extends TestCase
     public function testGetParent(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setParent($adminMock);
 
         $this->assertSame($adminMock, $field->getParent());
@@ -147,7 +146,7 @@ class FieldDescriptionTest extends TestCase
     public function testGetAdmin(): void
     {
         $adminMock = $this->createMock(AdminInterface::class);
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAdmin($adminMock);
 
         $this->assertSame($adminMock, $field->getAdmin());
@@ -160,7 +159,7 @@ class FieldDescriptionTest extends TestCase
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationAdmin($adminMock);
 
         $this->assertSame($adminMock, $field->getAssociationAdmin());
@@ -173,7 +172,7 @@ class FieldDescriptionTest extends TestCase
             ->method('setParentFieldDescription')
             ->with($this->isInstanceOf(FieldDescriptionInterface::class));
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
 
         $this->assertFalse($field->hasAssociationAdmin());
 
@@ -191,7 +190,7 @@ class FieldDescriptionTest extends TestCase
             }
         };
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setOption('code', 'myMethod');
 
         $this->assertSame($field->getValue($object), 'myMethodValue');
@@ -206,7 +205,7 @@ class FieldDescriptionTest extends TestCase
             }
         };
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
 
         $this->expectException(NoValueException::class);
 
@@ -220,7 +219,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping($assocationMapping);
 
         $this->assertSame($assocationMapping, $field->getAssociationMapping());
@@ -230,7 +229,7 @@ class FieldDescriptionTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setAssociationMapping('test');
     }
 
@@ -238,7 +237,7 @@ class FieldDescriptionTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping('test');
     }
 
@@ -249,7 +248,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame('integer', $field->getType());
@@ -262,7 +261,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame('integer', $field->getMappingType());
@@ -275,7 +274,7 @@ class FieldDescriptionTest extends TestCase
             'fieldName' => 'position',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('position');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame('position', $field->getFieldName());
@@ -294,7 +293,7 @@ class FieldDescriptionTest extends TestCase
             'targetDocument' => 'someValue',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
 
         $this->assertNull($field->getTargetEntity());
 
@@ -311,7 +310,7 @@ class FieldDescriptionTest extends TestCase
             'targetDocument' => 'someValue',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
 
         $this->assertNull($field->getTargetModel());
 
@@ -328,7 +327,7 @@ class FieldDescriptionTest extends TestCase
             'id' => true,
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertTrue($field->isIdentifier());
@@ -342,7 +341,7 @@ class FieldDescriptionTest extends TestCase
             'id' => 'someId',
         ];
 
-        $field = new FieldDescription();
+        $field = new FieldDescription('name');
         $field->setFieldMapping($fieldMapping);
 
         $this->assertSame($fieldMapping, $field->getFieldMapping());

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -113,8 +113,7 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('name');
+        $fieldDescription = new FieldDescription('name');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
         $this->modelManager->method('hasMetadata')->willReturn(true);
@@ -134,8 +133,7 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('associatedDocument');
+        $fieldDescription = new FieldDescription('associatedDocument');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['associatedDocument']);
         $fieldDescription->setAssociationMapping($classMetadata->associationMappings['associatedDocument']);
@@ -170,8 +168,7 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
             ],
         ], Guess::VERY_HIGH_CONFIDENCE);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
 
         $this->typeGuesser->method('guessType')->willReturn($guessType);
 
@@ -214,8 +211,7 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
 
         $this->filterFactory->method('create')->willReturn(new ModelFilter());
 

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -161,9 +161,8 @@ class FormContractorTest extends AbstractBuilderTestCase
         $admin = $this->createMock(AdminInterface::class);
         $admin->method('getModelManager')->willReturn($modelManager);
 
-        $fieldDescription = new FieldDescription();
+        $fieldDescription = new FieldDescription('name');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
-        $fieldDescription->setName('name');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
@@ -182,9 +181,8 @@ class FormContractorTest extends AbstractBuilderTestCase
         $admin = $this->createMock(AdminInterface::class);
         $admin->method('getModelManager')->willReturn($modelManager);
 
-        $fieldDescription = new FieldDescription();
+        $fieldDescription = new FieldDescription('associatedDocument');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
-        $fieldDescription->setName('associatedDocument');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['associatedDocument']);
         $fieldDescription->setAssociationMapping($classMetadata->associationMappings['associatedDocument']);
 

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -70,8 +70,7 @@ class ListBuilderTest extends AbstractBuilderTestCase
 
     public function testAddListActionField(): void
     {
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('foo');
+        $fieldDescription = new FieldDescription('foo');
 
         $list = $this->listBuilder->getBaseList();
 
@@ -97,8 +96,7 @@ class ListBuilderTest extends AbstractBuilderTestCase
                 new TypeGuess('actions', [], Guess::LOW_CONFIDENCE)
             );
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('_action');
+        $fieldDescription = new FieldDescription('_action');
 
         $list = $this->listBuilder->getBaseList();
 
@@ -119,8 +117,7 @@ class ListBuilderTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('name');
+        $fieldDescription = new FieldDescription('name');
         $fieldDescription->setOption('sortable', true);
         $fieldDescription->setType('string');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
@@ -142,8 +139,7 @@ class ListBuilderTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('associatedDocument');
+        $fieldDescription = new FieldDescription('associatedDocument');
         $fieldDescription->setOption('sortable', true);
         $fieldDescription->setType($type);
         $fieldDescription->setMappingType($type);
@@ -184,8 +180,7 @@ class ListBuilderTest extends AbstractBuilderTestCase
     public function testFixFieldDescriptionFixesType(string $expectedType, string $type): void
     {
         $this->modelManager->method('hasMetadata')->willReturn(false);
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('test');
+        $fieldDescription = new FieldDescription('test');
         $fieldDescription->setType($type);
 
         $this->listBuilder->fixFieldDescription($this->admin, $fieldDescription);
@@ -204,6 +199,6 @@ class ListBuilderTest extends AbstractBuilderTestCase
     public function testFixFieldDescriptionException(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->listBuilder->fixFieldDescription($this->admin, new FieldDescription());
+        $this->listBuilder->fixFieldDescription($this->admin, new FieldDescription('name'));
     }
 }

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -76,8 +76,7 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
     {
         $typeGuess = $this->createStub(TypeGuess::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
 
         $this->admin->expects($this->once())->method('attachAdminClass');
@@ -101,8 +100,7 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
 
     public function testAddFieldWithType(): void
     {
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
 
         $this->admin->expects($this->once())->method('addShowFieldDescription');
 
@@ -125,8 +123,7 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('name');
+        $fieldDescription = new FieldDescription('name');
         $fieldDescription->setType($type);
         $fieldDescription->setMappingType($mappingType);
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
@@ -163,8 +160,7 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
      */
     public function testFixFieldDescriptionFixesType(string $expectedType, string $type): void
     {
-        $fieldDescription = new FieldDescription();
-        $fieldDescription->setName('FakeName');
+        $fieldDescription = new FieldDescription('FakeName');
         $fieldDescription->setType($type);
 
         $this->showBuilder->fixFieldDescription($this->admin, $fieldDescription);
@@ -183,6 +179,6 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
     public function testFixFieldDescriptionException(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->showBuilder->fixFieldDescription($this->admin, new FieldDescription());
+        $this->showBuilder->fixFieldDescription($this->admin, new FieldDescription('name'));
     }
 }

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -118,14 +118,9 @@ final class ModelManagerTest extends TestCase
         $datagrid1 = $this->createStub(Datagrid::class);
         $datagrid2 = $this->createStub(Datagrid::class);
 
-        $field1 = new FieldDescription();
-        $field1->setName('field1');
-
-        $field2 = new FieldDescription();
-        $field2->setName('field2');
-
-        $field3 = new FieldDescription();
-        $field3->setName('field3');
+        $field1 = new FieldDescription('field1');
+        $field2 = new FieldDescription('field2');
+        $field3 = new FieldDescription('field3');
         $field3->setOption('sortable', 'field3sortBy');
 
         $datagrid1


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In sonata-project/admin-bundle 3.78 a deprecation was added to force to construct FieldDescription with `name` and `options`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed deprecation constructing `FieldDescription` without arguments.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
