### PR TITLE
Remove calls to ModelManager::getMetadata from Builders

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -68,24 +68,20 @@ class DatagridBuilder implements DatagridBuilderInterface
         // set default values
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
+        if ([] !== $fieldDescription->getFieldMapping()) {
+            $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $fieldDescription->getFieldMapping()));
 
-            // set the default field mapping
-            if (isset($metadata->fieldMappings[$lastPropertyName])) {
-                $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$lastPropertyName]));
-
-                if ('string' === $metadata->fieldMappings[$lastPropertyName]['type']) {
-                    $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
-                }
+            if ('string' === $fieldDescription->getFieldMapping()['type']) {
+                $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
             }
+        }
 
-            // set the default association mapping
-            if (isset($metadata->associationMappings[$lastPropertyName])) {
-                $fieldDescription->setOption('association_mapping', $fieldDescription->getOption('association_mapping', $metadata->associationMappings[$lastPropertyName]));
-            }
+        if ([] !== $fieldDescription->getAssociationMapping()) {
+            $fieldDescription->setOption('association_mapping', $fieldDescription->getOption('association_mapping', $fieldDescription->getAssociationMapping()));
+        }
 
-            $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $parentAssociationMappings));
+        if ([] !== $fieldDescription->getParentAssociationMappings()) {
+            $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
         }
 
         $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));

--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -51,20 +51,6 @@ class FormContractor implements FormContractorInterface
 
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            $metadata = $admin->getModelManager()->getMetadata($admin->getClass());
-
-            // set the default field mapping
-            if (isset($metadata->fieldMappings[$fieldDescription->getName()])) {
-                $fieldDescription->setFieldMapping($metadata->fieldMappings[$fieldDescription->getName()]);
-            }
-
-            // set the default association mapping
-            if (isset($metadata->associationMappings[$fieldDescription->getName()])) {
-                $fieldDescription->setAssociationMapping($metadata->associationMappings[$fieldDescription->getName()]);
-            }
-        }
-
         if (!$fieldDescription->getType()) {
             throw new \RuntimeException(sprintf(
                 'Please define a type for field `%s` in `%s`',

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -68,23 +68,11 @@ class ListBuilder implements ListBuilderInterface
 
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
-            $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
-
-            // set the default field mapping
-            if (isset($metadata->fieldMappings[$lastPropertyName])) {
-                $fieldDescription->setFieldMapping($metadata->fieldMappings[$lastPropertyName]);
-                if (false !== $fieldDescription->getOption('sortable')) {
-                    $fieldDescription->setOption('sortable', $fieldDescription->getOption('sortable', true));
-                    $fieldDescription->setOption('sort_parent_association_mappings', $fieldDescription->getOption('sort_parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
-                    $fieldDescription->setOption('sort_field_mapping', $fieldDescription->getOption('sort_field_mapping', $fieldDescription->getFieldMapping()));
-                }
-            }
-
-            // set the default association mapping
-            if (isset($metadata->associationMappings[$lastPropertyName])) {
-                $fieldDescription->setAssociationMapping($metadata->associationMappings[$lastPropertyName]);
+        if ([] !== $fieldDescription->getFieldMapping()) {
+            if (false !== $fieldDescription->getOption('sortable')) {
+                $fieldDescription->setOption('sortable', $fieldDescription->getOption('sortable', true));
+                $fieldDescription->setOption('sort_parent_association_mappings', $fieldDescription->getOption('sort_parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
+                $fieldDescription->setOption('sort_field_mapping', $fieldDescription->getOption('sort_field_mapping', $fieldDescription->getFieldMapping()));
             }
 
             $fieldDescription->setOption('_sort_order', $fieldDescription->getOption('_sort_order', 'ASC'));

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -62,21 +62,6 @@ class ShowBuilder implements ShowBuilderInterface
     {
         $fieldDescription->setAdmin($admin);
 
-        if ($admin->getModelManager()->hasMetadata($admin->getClass())) {
-            [$metadata, $lastPropertyName, $parentAssociationMappings] = $admin->getModelManager()->getParentMetadataForProperty($admin->getClass(), $fieldDescription->getName());
-            $fieldDescription->setParentAssociationMappings($parentAssociationMappings);
-
-            // set the default field mapping
-            if (isset($metadata->fieldMappings[$lastPropertyName])) {
-                $fieldDescription->setFieldMapping($metadata->fieldMappings[$lastPropertyName]);
-            }
-
-            // set the default association mapping
-            if (isset($metadata->associationMappings[$lastPropertyName])) {
-                $fieldDescription->setAssociationMapping($metadata->associationMappings[$lastPropertyName]);
-            }
-        }
-
         if (!$fieldDescription->getType()) {
             throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -116,13 +116,6 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
         $fieldDescription = new FieldDescription('name');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
-        $this->modelManager->method('hasMetadata')->willReturn(true);
-
-        $this->modelManager
-            ->expects($this->once())
-            ->method('getParentMetadataForProperty')
-            ->willReturn([$classMetadata, 'name', $parentAssociationMapping = []]);
-
         $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
         $this->assertSame($classMetadata->fieldMappings['name'], $fieldDescription->getOption('field_mapping'));
@@ -141,13 +134,6 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
         $this->admin
             ->expects($this->once())
             ->method('attachAdminClass');
-
-        $this->modelManager->method('hasMetadata')->willReturn(true);
-
-        $this->modelManager
-            ->expects($this->once())
-            ->method('getParentMetadataForProperty')
-            ->willReturn([$classMetadata, 'associatedDocument', $parentAssociationMapping = []]);
 
         $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
@@ -171,10 +157,6 @@ final class DatagridBuilderTest extends AbstractBuilderTestCase
         $fieldDescription = new FieldDescription('test');
 
         $this->typeGuesser->method('guessType')->willReturn($guessType);
-
-        $this->modelManager
-            ->expects($this->once())
-            ->method('hasMetadata')->willReturn(false);
 
         $this->admin->method('getCode')->willReturn('someFakeCode');
 

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -122,10 +122,6 @@ class ListBuilderTest extends AbstractBuilderTestCase
         $fieldDescription->setType('string');
         $fieldDescription->setFieldMapping($classMetadata->fieldMappings['name']);
 
-        $this->modelManager
-            ->method('getParentMetadataForProperty')
-            ->willReturn([$classMetadata, 'name', $parentAssociationMapping = []]);
-
         $this->listBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
         $this->assertSame('@SonataAdmin/CRUD/list_string.html.twig', $fieldDescription->getTemplate());
@@ -149,10 +145,6 @@ class ListBuilderTest extends AbstractBuilderTestCase
         $this->admin
             ->expects($this->once())
             ->method('attachAdminClass');
-
-        $this->modelManager
-            ->method('getParentMetadataForProperty')
-            ->willReturn([$classMetadata, 'associatedDocument', $parentAssociationMapping = []]);
 
         $this->listBuilder->fixFieldDescription($this->admin, $fieldDescription);
 

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -130,9 +130,6 @@ final class ShowBuilderTest extends AbstractBuilderTestCase
 
         $this->admin->expects($this->once())->method('attachAdminClass');
 
-        $this->modelManager->method('getParentMetadataForProperty')
-            ->willReturn([$classMetadata, 'name', $parentAssociationMapping = []]);
-
         $this->showBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
         $this->assertSame($template, $fieldDescription->getTemplate());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/6375 for a little bit of context.

When a `FieldDescription` is created through `ModelManager::getNewFieldDescriptionInstance` it adds metadata info to the instance, so there is no need to extract again this metadata in Builder classes.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

I've removed the changelog since this shouldn't affect the end user.
