### PR TITLE
Pass collection_by_reference instead of by_reference

### DIFF
--- a/src/Builder/FormContractor.php
+++ b/src/Builder/FormContractor.php
@@ -209,7 +209,7 @@ class FormContractor implements FormContractorInterface
         ];
 
         if (isset($formOptions['by_reference'])) {
-            $typeOptions['by_reference'] = $formOptions['by_reference'];
+            $typeOptions['collection_by_reference'] = $formOptions['by_reference'];
         }
 
         return $typeOptions;

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -118,7 +118,7 @@ class FormContractorTest extends AbstractBuilderTestCase
             $this->assertTrue($options['modifiable']);
             $this->assertSame($fieldDescription, $options['type_options']['sonata_field_description']);
             $this->assertSame($modelClass, $options['type_options']['data_class']);
-            $this->assertFalse($options['type_options']['by_reference']);
+            $this->assertFalse($options['type_options']['collection_by_reference']);
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1197

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `FormContractor::getDefaultOptions()` passes `collection_by_reference` option instead of `by_reference` to `AdminType` in order to respect the new API
```