### PR TITLE
Return null instead of false respecting the interface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\Guesser\TypeGuesser
+
+`TypeGuesser::guessType()` returns `null` instead of `false` when there is no metadata found for the property
+respecting `TypeGuesserInterface::guessType()`.
+
 ### Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager
 
 Deprecated passing `null` as argument 2 for `find()`.

--- a/src/Guesser/FilterTypeGuesser.php
+++ b/src/Guesser/FilterTypeGuesser.php
@@ -41,7 +41,7 @@ class FilterTypeGuesser extends AbstractTypeGuesser
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
         if (!$ret = $this->getParentMetadataForProperty($class, $property, $modelManager)) {
-            return false;
+            return null;
         }
 
         $options = [

--- a/tests/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Guesser/FilterTypeGuesserTest.php
@@ -82,7 +82,7 @@ class FilterTypeGuesserTest extends TestCase
 
         $result = $this->guesser->guessType($class, $property, $this->modelManager);
 
-        $this->assertFalse($result);
+        $this->assertNull($result);
     }
 
     public function testGuessTypeWithAssociation(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The return type of the [`TypeGuesserInterface::guessType`](https://github.com/sonata-project/SonataAdminBundle/blob/d0cffae16f7d2e5badc995581b90f5dba583eabe/src/Guesser/TypeGuesserInterface.php#L28) is null or TypeGuess.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the return type of `TypeGuesser::guessType`, it must return `null` or `TypeGuess`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
