### PR TITLE
Fix returning nested array with identifiers

### DIFF
--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -292,7 +292,7 @@ class ModelManager implements ModelManagerInterface
 
     public function getIdentifierFieldNames($class)
     {
-        return [$this->getMetadata($class)->getIdentifier()];
+        return $this->getMetadata($class)->getIdentifier();
     }
 
     public function getNormalizedIdentifier($document)

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -33,6 +33,7 @@ use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AbstractDocument;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\AssociatedDocument;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\ContainerDocument;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentWithReferences;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\EmbeddedDocument;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\ProtectedDocument;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\SimpleDocumentWithPrivateSetter;
@@ -63,6 +64,36 @@ final class ModelManagerTest extends TestCase
 
         $this->registry = $this->createStub(ManagerRegistry::class);
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    public function testGetIdentifierFieldNames(): void
+    {
+        $dm = $this->createStub(DocumentManager::class);
+
+        $modelManager = new ModelManager($this->registry, $this->propertyAccessor);
+
+        $this->registry
+            ->method('getManagerForClass')
+            ->willReturn($dm);
+
+        $metadataFactory = $this->createStub(ClassMetadataFactory::class);
+
+        $dm
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+
+        $documentWithReferencesClass = DocumentWithReferences::class;
+
+        $classMetadata = $this->getMetadataForDocumentWithAnnotations($documentWithReferencesClass);
+
+        $metadataFactory->method('getMetadataFor')
+            ->willReturnMap(
+                [
+                    [$documentWithReferencesClass, $classMetadata],
+                ]
+            );
+
+        $this->assertSame(['id'], $modelManager->getIdentifierFieldNames($documentWithReferencesClass));
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[ClassMetadata::getIdentifier from `doctrine/mongodb-odm`](https://github.com/doctrine/mongodb-odm/blob/9992f2a9c2bd8dc9ded2c9047742cb220d38ff0e/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L614) already returns an array with the identifiers.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed returning an array of identifiers in `ModelManager::getIdentifierFieldNames`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
