### PR TITLE
Deprecate ModelManager methods already deprecated in the interface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -14,6 +14,10 @@ respecting `TypeGuesserInterface::guessType()`.
 Deprecated passing `null` as argument 2 for `find()`.
 Deprecated passing `null` or an object which is in state new or removed as argument 1 for `getNormalizedIdentifier()`.
 Deprecated passing `null` as argument 1 for `getUrlSafeIdentifier()`.
+Deprecated `getModelIdentifier()`.
+Deprecated `getDefaultSortValues()`.
+Deprecated `getDefaultPerPageOptions()`.
+Deprecated `modelTransform()`.
 
 UPGRADE FROM 3.3 to 3.4
 =======================

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.78",
+        "sonata-project/admin-bundle": "^3.80",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -302,8 +302,18 @@ class ModelManager implements ModelManagerInterface
         return $query->execute();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getModelIdentifier($class)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->getMetadata($class)->identifier;
     }
 
@@ -482,8 +492,18 @@ class ModelManager implements ModelManagerInterface
         return ['filter' => $values];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getDefaultSortValues($class)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [
             '_sort_order' => 'ASC',
             '_sort_by' => $this->getModelIdentifier($class),
@@ -492,13 +512,33 @@ class ModelManager implements ModelManagerInterface
         ];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getDefaultPerPageOptions(string $class): array
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return [10, 25, 50, 100, 250];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function modelTransform($class, $instance)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $instance;
     }
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -317,11 +317,22 @@ final class ModelManagerTest extends TestCase
         $this->assertTrue($collection->isEmpty());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testModelTransform(): void
     {
         $model = new ModelManager($this->registry, $this->propertyAccessor);
 
         $instance = new \stdClass();
+
+        $this->expectDeprecation(sprintf(
+            'Method %s::modelTransform() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.',
+            ModelManager::class
+        ));
+
         $result = $model->modelTransform('thisIsNotUsed', $instance);
 
         $this->assertSame($instance, $result);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

These methods are deprecated in [ModelManagerInterface](https://github.com/sonata-project/SonataAdminBundle/blob/337fcf9b4c048702444fecfa2b97fb2ac75b2927/src/Model/ModelManagerInterface.php#L29).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `ModelManager::getModelIdentifier()`.
- Deprecated `ModelManager::getDefaultSortValues()`.
- Deprecated `ModelManager::getDefaultPerPageOptions()`.
- Deprecated `ModelManager::modelTransform()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
