### PR TITLE
Add DataSourceInterface implementation

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -18,6 +18,8 @@ Deprecated `getModelIdentifier()`.
 Deprecated `getDefaultSortValues()`.
 Deprecated `getDefaultPerPageOptions()`.
 Deprecated `modelTransform()`.
+Deprecated `getDataSourceIterator()`. You SHOULD use
+`Sonata\DoctrineMongoDBAdminBundle\Exporter\DataSource::createIterator` instead.
 
 UPGRADE FROM 3.3 to 3.4
 =======================

--- a/src/Exporter/DataSource.php
+++ b/src/Exporter/DataSource.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Exporter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Exporter\DataSourceInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\Exporter\Source\DoctrineODMQuerySourceIterator;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+
+final class DataSource implements DataSourceInterface
+{
+    public function createIterator(ProxyQueryInterface $query, array $fields): SourceIteratorInterface
+    {
+        if (!$query instanceof ProxyQuery) {
+            throw new \LogicException(sprintf('Argument 1 MUST be an instance of "%s"', ProxyQuery::class));
+        }
+
+        $query->setFirstResult(null);
+        $query->setMaxResults(null);
+
+        return new DoctrineODMQuerySourceIterator($query->getQueryBuilder()->getQuery(), $fields);
+    }
+}

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -408,6 +408,11 @@ class ModelManager implements ModelManagerInterface
         $documentManager->clear();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getDataSourceIterator(DatagridInterface $datagrid, array $fields, $firstResult = null, $maxResult = null)
     {
         $datagrid->buildPager();

--- a/src/Resources/config/doctrine_mongodb.php
+++ b/src/Resources/config/doctrine_mongodb.php
@@ -16,6 +16,7 @@ use Sonata\DoctrineMongoDBAdminBundle\Builder\DatagridBuilder;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\ListBuilder;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\ShowBuilder;
+use Sonata\DoctrineMongoDBAdminBundle\Exporter\DataSource;
 use Sonata\DoctrineMongoDBAdminBundle\Guesser\FilterTypeGuesser;
 use Sonata\DoctrineMongoDBAdminBundle\Guesser\TypeGuesser;
 use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
@@ -90,5 +91,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 [
                     new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_datagrid'),
                 ],
-            ]);
+            ])
+
+        ->set('sonata.admin.data_source.doctrine_mongodb', DataSource::class)
+    ;
 };

--- a/tests/Exporter/DataSourceTest.php
+++ b/tests/Exporter/DataSourceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Exporter;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\Query;
+use MongoDB\Collection;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Exporter\DataSource;
+
+final class DataSourceTest extends TestCase
+{
+    /**
+     * @var DataSource
+     */
+    private $dataSource;
+
+    protected function setUp(): void
+    {
+        $this->dataSource = new DataSource();
+    }
+
+    public function testItResetsTheQueryBeforeCreatingIterator(): void
+    {
+        $query = new Query(
+            $this->createStub(DocumentManager::class),
+            $this->createStub(ClassMetadata::class),
+            $this->createStub(Collection::class),
+            ['type' => Query::TYPE_FIND]
+        );
+
+        $queryBuilder = $this->createStub(Builder::class);
+        $queryBuilder
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+        $proxyQuery->setFirstResult(10);
+        $proxyQuery->setMaxResults(10);
+
+        $this->dataSource->createIterator($proxyQuery, []);
+
+        $this->assertNull($proxyQuery->getFirstResult());
+        $this->assertNull($proxyQuery->getMaxResults());
+    }
+
+    public function testItThrowAnExceptionWithInvalidQuery(): void
+    {
+        $proxyQuery = $this->createStub(ProxyQueryInterface::class);
+
+        $this->expectException(\LogicException::class);
+
+        $this->dataSource->createIterator($proxyQuery, []);
+    }
+}

--- a/tests/Functional/ReferenceMappingTest.php
+++ b/tests/Functional/ReferenceMappingTest.php
@@ -31,7 +31,7 @@ final class ReferenceMappingTest extends BasePantherTestCase
         $form[$attributeName] = 'A wonderful book';
 
         $crawler->filter('.field-container .sonata-ba-action[title="Add new"]')->click();
-        $crawler = $this->client->waitFor('.author_id');
+        $crawler = $this->client->waitForVisibility('.author_id');
 
         $authorForm = $this->createAuthorForm($crawler);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is the implementation of https://github.com/sonata-project/SonataAdminBundle/pull/6463, it is based on the current code of `Modelmanager::getDataSourceIterator()` method.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `DataSource` to provide a `DataSourceInterface` implementation.
### Deprecated
- Deprecated `ModelManager::getDataSourceIterator()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
