### PR TITLE
Remove mocks of final classes

### DIFF
--- a/tests/AbstractModelManagerTestCase.php
+++ b/tests/AbstractModelManagerTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+use Doctrine\Persistence\Mapping\ClassMetadataFactory;
+use PHPUnit\Framework\MockObject\Stub\Stub;
+use PHPUnit\Framework\TestCase;
+use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+abstract class AbstractModelManagerTestCase extends TestCase
+{
+    /**
+     * @var ModelManager
+     */
+    protected $modelManager;
+
+    /**
+     * @var DocumentManager&Stub
+     */
+    protected $documentManager;
+
+    /**
+     * @var ClassMetadataFactory&Stub
+     */
+    protected $metadataFactory;
+
+    protected function setUp(): void
+    {
+        $this->metadataFactory = $this->createStub(ClassMetadataFactory::class);
+
+        $this->documentManager = $this->createStub(DocumentManager::class);
+        $this->documentManager
+            ->method('getMetadataFactory')
+            ->willReturn($this->metadataFactory);
+
+        $managerRegistry = $this->createStub(ManagerRegistry::class);
+        $managerRegistry
+            ->method('getManagerForClass')
+            ->willReturn($this->documentManager);
+
+        $this->modelManager = new ModelManager($managerRegistry, PropertyAccess::createPropertyAccessor());
+    }
+
+    protected function getMetadataForDocumentWithAnnotations(string $class): ClassMetadata
+    {
+        $classMetadata = new ClassMetadata($class);
+        $reader = new AnnotationReader();
+
+        $annotationDriver = new AnnotationDriver($reader);
+        $annotationDriver->loadMetadataForClass($class, $classMetadata);
+
+        return $classMetadata;
+    }
+}

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -22,16 +22,15 @@ use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelType;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Admin\FieldDescription;
 use Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor;
-use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\AbstractModelManagerTestCase;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentWithReferences;
 use Sonata\Form\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 
-class FormContractorTest extends AbstractBuilderTestCase
+class FormContractorTest extends AbstractModelManagerTestCase
 {
     /**
      * @var FormFactoryInterface&MockObject
@@ -45,6 +44,8 @@ class FormContractorTest extends AbstractBuilderTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $this->formFactory = $this->createMock(FormFactoryInterface::class);
 
         $this->formContractor = new FormContractor($this->formFactory);
@@ -64,10 +65,9 @@ class FormContractorTest extends AbstractBuilderTestCase
     public function testDefaultOptionsForSonataFormTypes(): void
     {
         $admin = $this->createMock(AdminInterface::class);
-        $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelClass = 'FooEntity';
 
-        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getModelManager')->willReturn($this->modelManager);
         $admin->method('getClass')->willReturn($modelClass);
 
         // NEXT_MAJOR: Mock `FieldDescriptionInterface` instead and replace `getTargetEntity()` with `getTargetModel().
@@ -94,7 +94,7 @@ class FormContractorTest extends AbstractBuilderTestCase
             $options = $this->formContractor->getDefaultOptions($formType, $fieldDescription);
             $this->assertSame($fieldDescription, $options['sonata_field_description']);
             $this->assertSame($modelClass, $options['class']);
-            $this->assertSame($modelManager, $options['model_manager']);
+            $this->assertSame($this->modelManager, $options['model_manager']);
         }
 
         // admin type
@@ -125,11 +125,10 @@ class FormContractorTest extends AbstractBuilderTestCase
     public function testAdminClassAttachForNotMappedField(): void
     {
         // Given
-        $modelManager = $this->createMock(ModelManager::class);
-        $modelManager->method('hasMetadata')->willReturn(false);
+        $this->metadataFactory->method('hasMetadataFor')->willReturn(false);
 
         $admin = $this->createMock(AdminInterface::class);
-        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getModelManager')->willReturn($this->modelManager);
 
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->method('getMappingType')->willReturn(ClassMetadata::ONE);
@@ -154,12 +153,11 @@ class FormContractorTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $modelManager = $this->createMock(ModelManager::class);
-        $modelManager->method('hasMetadata')->willReturn(true);
-        $modelManager->method('getMetadata')->willReturn($classMetadata);
+        $this->metadataFactory->method('hasMetadataFor')->willReturn(true);
+        $this->documentManager->method('getClassMetadata')->willReturn($classMetadata);
 
         $admin = $this->createMock(AdminInterface::class);
-        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getModelManager')->willReturn($this->modelManager);
 
         $fieldDescription = new FieldDescription('name');
         $fieldDescription->setMappingType(ClassMetadata::ONE);
@@ -174,12 +172,11 @@ class FormContractorTest extends AbstractBuilderTestCase
     {
         $classMetadata = $this->getMetadataForDocumentWithAnnotations(DocumentWithReferences::class);
 
-        $modelManager = $this->createMock(ModelManager::class);
-        $modelManager->method('hasMetadata')->willReturn(true);
-        $modelManager->method('getMetadata')->willReturn($classMetadata);
+        $this->metadataFactory->method('hasMetadataFor')->willReturn(true);
+        $this->documentManager->method('getClassMetadata')->willReturn($classMetadata);
 
         $admin = $this->createMock(AdminInterface::class);
-        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getModelManager')->willReturn($this->modelManager);
 
         $fieldDescription = new FieldDescription('associatedDocument');
         $fieldDescription->setMappingType(ClassMetadata::ONE);

--- a/tests/Guesser/TypeGuesserTest.php
+++ b/tests/Guesser/TypeGuesserTest.php
@@ -16,22 +16,15 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Guesser;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Mapping\MappingException;
 use Doctrine\ODM\MongoDB\Types\Type;
-use PHPUnit\Framework\MockObject\Stub;
-use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineMongoDBAdminBundle\Guesser\TypeGuesser;
-use Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\AbstractModelManagerTestCase;
 use Symfony\Component\Form\Guess\Guess;
 
 /**
  * @author Marko Kunic <kunicmarko20@gmail.com>
  */
-final class TypeGuesserTest extends TestCase
+final class TypeGuesserTest extends AbstractModelManagerTestCase
 {
-    /**
-     * @var Stub&ModelManager
-     */
-    private $modelManager;
-
     /**
      * @var TypeGuesser
      */
@@ -39,7 +32,8 @@ final class TypeGuesserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->modelManager = $this->createStub(ModelManager::class);
+        parent::setUp();
+
         $this->guesser = new TypeGuesser();
     }
 
@@ -47,9 +41,9 @@ final class TypeGuesserTest extends TestCase
     {
         $class = 'FakeClass';
         $property = 'fakeProperty';
-        $this->modelManager
-            ->method('getParentMetadataForProperty')
-            ->with($class, $property)
+
+        $this->documentManager
+            ->method('getClassMetaData')
             ->willThrowException(new MappingException());
 
         $result = $this->guesser->guessType($class, $property, $this->modelManager);
@@ -75,14 +69,9 @@ final class TypeGuesserTest extends TestCase
 
         $classMetadata->fieldMappings = [$property => ['type' => $mappingType]];
 
-        $this->modelManager
-            ->method('getParentMetadataForProperty')
-            ->with($class, $property)
-            ->willReturn([
-                $classMetadata,
-                $property,
-                'notUsed',
-            ]);
+        $this->documentManager
+            ->method('getClassMetadata')
+            ->willReturn($classMetadata);
 
         $result = $this->guesser->guessType($class, $property, $this->modelManager);
 
@@ -124,14 +113,9 @@ final class TypeGuesserTest extends TestCase
             ->with($property)
             ->willReturn($type);
 
-        $this->modelManager
-            ->method('getParentMetadataForProperty')
-            ->with($class, $property)
-            ->willReturn([
-                $classMetadata,
-                $property,
-                'notUsed',
-            ]);
+        $this->documentManager
+            ->method('getClassMetadata')
+            ->willReturn($classMetadata);
 
         $result = $this->guesser->guessType($class, $property, $this->modelManager);
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -471,7 +471,7 @@ final class ModelManagerTest extends TestCase
      */
     public function supportsQueryDataProvider(): iterable
     {
-        yield [true, $this->createStub(ProxyQuery::class)];
+        yield [true, new ProxyQuery($this->createStub(Builder::class))];
         yield [true, $this->createStub(Builder::class)];
         yield [false, new \stdClass()];
     }


### PR DESCRIPTION
In next major version we will not be able to mock them.

It should be fine after merging: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/486/commits/1e2d09082677a37b7e7bad39b605d6934418e70d (https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/486)