### PR TITLE
Fix deprecations introduced in admin-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.83",
+        "sonata-project/admin-bundle": "^3.84",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -167,7 +167,6 @@ class DatagridBuilder implements DatagridBuilderInterface
     public function getBaseDatagrid(AdminInterface $admin, array $values = [])
     {
         $pager = new Pager();
-        $pager->setCountColumn($admin->getModelManager()->getIdentifierFieldNames($admin->getClass()));
 
         $defaultOptions = [];
         if ($this->csrfTokenEnabled) {

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -29,6 +29,7 @@ abstract class Filter extends BaseFilter
      */
     public function apply($query, $filterData)
     {
+        // NEXT_MAJOR: Remove next line.
         $this->value = $filterData;
 
         $field = $this->getParentAssociationMappings() ? $this->getName() : $this->getFieldName();

--- a/tests/Admin/FieldDescriptionTest.php
+++ b/tests/Admin/FieldDescriptionTest.php
@@ -128,10 +128,13 @@ class FieldDescriptionTest extends TestCase
         $this->assertSame($field->getFieldName(), 'New field description name');
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     */
     public function testSetNameDoesNotSetFieldNameWhenSetBefore(): void
     {
         $field = new FieldDescription('name');
-        $field->setFieldName('field name');
+        $field->setFieldName('field name', 'sonata_deprecation_mute');
         $field->setName('New field description name');
 
         $this->assertSame($field->getFieldName(), 'field name');

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -69,6 +69,11 @@ class FilterTest extends TestCase
         $this->assertSame(['class' => 'FooBar'], $filter->getFieldOptions());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testValues(): void
     {
         $filter = new FilterTest_Filter();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In https://github.com/sonata-project/SonataAdminBundle/releases/tag/3.84.0 some deprecations where introduced, this PR address these deprecations.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed calling to deprecated `Pager::setCountColumn()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
