### PR TITLE
handle SonataAdminBundle Pager::nbresults deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.84",
+        "sonata-project/admin-bundle": "^3.86",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -49,13 +49,6 @@ class Pager extends BasePager
         return $deprecatedCount;
     }
 
-    public function setResultsCount(int $count): void
-    {
-        $this->resultsCount = $count;
-        // NEXT_MAJOR: Remove this line.
-        $this->setNbResults($count, 'sonata_deprecation_mute');
-    }
-
     /**
      * NEXT_MAJOR: remove this method.
      *
@@ -156,5 +149,12 @@ class Pager extends BasePager
         }
 
         return (int) $countQuery->count()->getQuery()->execute();
+    }
+
+    private function setResultsCount(int $count): void
+    {
+        $this->resultsCount = $count;
+        // NEXT_MAJOR: Remove this line.
+        $this->setNbResults($count, 'sonata_deprecation_mute');
     }
 }

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -27,15 +27,71 @@ class Pager extends BasePager
 {
     protected $queryBuilder = null;
 
-    public function computeNbResult()
-    {
-        $countQuery = clone $this->getQuery();
+    /**
+     * @var int
+     */
+    private $resultsCount = 0;
 
-        if (\count($this->getParameters()) > 0) {
-            $countQuery->setParameters($this->getParameters());
+    public function countResults(): int
+    {
+        // NEXT_MAJOR: just return "$this->resultsCount" directly.
+        $deprecatedCount = $this->getNbResults('sonata_deprecation_mute');
+
+        if ($deprecatedCount === $this->resultsCount) {
+            return $this->resultsCount;
         }
 
-        return $countQuery->count()->getQuery()->execute();
+        @trigger_error(sprintf(
+            'Relying on the protected property "%s::$nbResults" and its getter/setter is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will fail 4.0. Use "countResults()" and "setResultsCount()" instead.',
+            self::class,
+        ), E_USER_DEPRECATED);
+
+        return $deprecatedCount;
+    }
+
+    public function setResultsCount(int $count): void
+    {
+        $this->resultsCount = $count;
+        // NEXT_MAJOR: Remove this line.
+        $this->setNbResults($count, 'sonata_deprecation_mute');
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x
+     *
+     * @return int
+     */
+    public function getNbResults()
+    {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in 4.0. Use "countResults()" instead.',
+                __METHOD__,
+            ), E_USER_DEPRECATED);
+        }
+
+        return $this->nbResults;
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x
+     *
+     * @return int
+     */
+    public function computeNbResult()
+    {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in 4.0.',
+                __METHOD__,
+            ), E_USER_DEPRECATED);
+        }
+
+        return $this->computeResultsCount();
     }
 
     public function getResults()
@@ -50,7 +106,7 @@ class Pager extends BasePager
     {
         $this->resetIterator();
 
-        $this->setNbResults($this->computeNbResult());
+        $this->setResultsCount($this->computeNbResult('sonata_deprecation_mute'));
 
         $this->getQuery()->setFirstResult(0);
         $this->getQuery()->setMaxResults(0);
@@ -59,15 +115,46 @@ class Pager extends BasePager
             $this->getQuery()->setParameters($this->getParameters());
         }
 
-        if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->getNbResults()) {
+        if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->countResults()) {
             $this->setLastPage(0);
         } else {
             $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
 
-            $this->setLastPage((int) ceil($this->getNbResults() / $this->getMaxPerPage()));
+            $this->setLastPage((int) ceil($this->countResults() / $this->getMaxPerPage()));
 
             $this->getQuery()->setFirstResult($offset);
             $this->getQuery()->setMaxResults($this->getMaxPerPage());
         }
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x
+     *
+     * @param int $nb
+     */
+    protected function setNbResults($nb)
+    {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in 4.0. Use "setResultsCount()" instead.',
+                __METHOD__,
+            ), E_USER_DEPRECATED);
+        }
+
+        $this->nbResults = $nb;
+        $this->resultsCount = (int) $nb;
+    }
+
+    private function computeResultsCount(): int
+    {
+        $countQuery = clone $this->getQuery();
+
+        if (\count($this->getParameters()) > 0) {
+            $countQuery->setParameters($this->getParameters());
+        }
+
+        return (int) $countQuery->count()->getQuery()->execute();
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

See 
https://github.com/sonata-project/SonataAdminBundle/pull/6732
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1257

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- implemented `Sonata\AdminBundle\Datagrid\PagerInterface::countResults()`

### Deprecated
- `Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager::computeNbResult()`
- `Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager::getNbResults()`
- `Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager::setNbResults()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
