### PR TITLE
Avoid triggering deprecations from Pager

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,15 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager
+
+Deprecated `computeNbResult()` method.
+Deprecated `getNbResults()` method, you SHOULD use `countResults()` instead.
+Deprecated `setNbResults()` method.
+
 UPGRADE FROM 3.5 to 3.6
 =======================
 

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -97,15 +97,19 @@ class Pager extends BasePager
      */
     public function init()
     {
-        $this->resetIterator();
+        // NEXT_MAJOR: Remove next line.
+        $this->resetIterator('sonata_deprecation_mute');
 
+        // NEXT_MAJOR: Remove next line and uncomment the next one.
         $this->setResultsCount($this->computeNbResult('sonata_deprecation_mute'));
+        // $this->setResultsCount($this->computeResultsCount());
 
         $this->getQuery()->setFirstResult(0);
         $this->getQuery()->setMaxResults(0);
 
-        if (\count($this->getParameters()) > 0) {
-            $this->getQuery()->setParameters($this->getParameters());
+        // NEXT_MAJOR: Remove this block.
+        if (\count($this->getParameters('sonata_deprecation_mute')) > 0) {
+            $this->getQuery()->setParameters($this->getParameters('sonata_deprecation_mute'));
         }
 
         if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->countResults()) {
@@ -144,8 +148,9 @@ class Pager extends BasePager
     {
         $countQuery = clone $this->getQuery();
 
-        if (\count($this->getParameters()) > 0) {
-            $countQuery->setParameters($this->getParameters());
+        // NEXT_MAJOR: Remove this block.
+        if (\count($this->getParameters('sonata_deprecation_mute')) > 0) {
+            $countQuery->setParameters($this->getParameters('sonata_deprecation_mute'));
         }
 
         return (int) $countQuery->count()->getQuery()->execute();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed triggering deprecations from `Pager`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
