### PR TITLE
[Tests] Split fixtures into files

### DIFF
--- a/tests/App/DataFixtures/MongoDB/AuthorFixtures.php
+++ b/tests/App/DataFixtures/MongoDB/AuthorFixtures.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\App\DataFixtures\MongoDB;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Address;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Author;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\PhoneNumber;
+
+final class AuthorFixtures extends Fixture
+{
+    public const AUTHOR = 'author';
+
+    public function load(ObjectManager $manager): void
+    {
+        $author = new Author('author_id', 'Miguel de Cervantes');
+        $author->setAddress(new Address('Somewhere in La Mancha, in a place whose name I do not care to remember'));
+        $author->addPhoneNumber(new PhoneNumber('666-666-666'));
+
+        $manager->persist($author);
+        $manager->flush();
+
+        $this->addReference(self::AUTHOR, $author);
+    }
+}

--- a/tests/App/DataFixtures/MongoDB/BookFixtures.php
+++ b/tests/App/DataFixtures/MongoDB/BookFixtures.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\App\DataFixtures\MongoDB;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Book;
+
+final class BookFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $book = new Book('book_id', 'Don Quixote', $this->getReference(AuthorFixtures::AUTHOR));
+        $book->addCategory($this->getReference(CategoryFixtures::CATEGORY));
+
+        $manager->persist($book);
+        $manager->flush();
+    }
+
+    /**
+     * @phpstan-return class-string[]
+     */
+    public function getDependencies(): array
+    {
+        return [
+            CategoryFixtures::class,
+            AuthorFixtures::class,
+        ];
+    }
+}

--- a/tests/App/DataFixtures/MongoDB/CategoryFixtures.php
+++ b/tests/App/DataFixtures/MongoDB/CategoryFixtures.php
@@ -15,29 +15,21 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\App\DataFixtures\MongoDB;
 
 use Doctrine\Bundle\MongoDBBundle\Fixture\Fixture;
 use Doctrine\Persistence\ObjectManager;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Address;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Author;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Book;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Category;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\PhoneNumber;
 
-final class AppFixtures extends Fixture
+final class CategoryFixtures extends Fixture
 {
+    public const CATEGORY = 'category_novel';
+
     public function load(ObjectManager $manager): void
     {
         $dystopianCategory = new Category('category_dystopian', 'Dystopian');
         $novelCategory = new Category('category_novel', 'Novel');
 
-        $author = new Author('author_id', 'Miguel de Cervantes');
-        $author->setAddress(new Address('Somewhere in La Mancha, in a place whose name I do not care to remember'));
-        $author->addPhoneNumber(new PhoneNumber('666-666-666'));
-        $book = new Book('book_id', 'Don Quixote', $author);
-        $book->addCategory($novelCategory);
-
-        $manager->persist($author);
         $manager->persist($novelCategory);
         $manager->persist($dystopianCategory);
-        $manager->persist($book);
         $manager->flush();
+
+        $this->addReference(self::CATEGORY, $novelCategory);
     }
 }

--- a/tests/App/config/services.php
+++ b/tests/App/config/services.php
@@ -11,13 +11,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Doctrine\Bundle\MongoDBBundle\DependencyInjection\Compiler\FixturesCompilerPass;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Admin\AddressAdmin;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Admin\AuthorAdmin;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Admin\BookAdmin;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Admin\CategoryAdmin;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Admin\PhoneNumberAdmin;
-use Sonata\DoctrineMongoDBAdminBundle\Tests\App\DataFixtures\MongoDB\AppFixtures;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Address;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Author;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Book;
@@ -27,6 +25,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->load('Sonata\\DoctrineMongoDBAdminBundle\\Tests\\App\\DataFixtures\\', dirname(__DIR__).'/DataFixtures')
 
         ->set(CategoryAdmin::class)
             ->public()
@@ -87,8 +89,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 PhoneNumber::class,
                 null,
             ])
-
-        ->set(AppFixtures::class)
-            ->tag(FixturesCompilerPass::FIXTURE_TAG)
     ;
 };


### PR DESCRIPTION
This makes easier to add more fixtures and also autowiring and autoconfiguring have been added to fixture files, so there is no need to register new fixture files.