### PR TITLE
Deprecate Pager::getResults in favor of getCurrentPageResults

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -9,6 +9,7 @@ UPGRADE FROM 3.x to 3.x
 Deprecated `computeNbResult()` method.
 Deprecated `getNbResults()` method, you SHOULD use `countResults()` instead.
 Deprecated `setNbResults()` method.
+Deprecated `getResults()` method.
 
 UPGRADE FROM 3.5 to 3.6
 =======================

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.86",
+        "sonata-project/admin-bundle": "^3.87",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "psalm/plugin-symfony": "^2.0",
         "symfony/browser-kit": "^4.4 || ^5.1",
         "symfony/css-selector": "^4.4 || ^5.1",
-        "symfony/panther": "^0.8.0",
+        "symfony/panther": "^0.9.0",
         "symfony/phpunit-bridge": "^5.1.8",
         "vimeo/psalm": "^4.1.1"
     },

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -87,9 +87,25 @@ class Pager extends BasePager
         return $this->computeResultsCount();
     }
 
-    public function getResults()
+    public function getCurrentPageResults(): iterable
     {
         return $this->getQuery()->execute();
+    }
+
+    /**
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x.
+     */
+    public function getResults()
+    {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will'
+        .' be removed in 4.0. Use "getCurrentPageResults()" instead.',
+            __METHOD__,
+        ), E_USER_DEPRECATED);
+
+        return $this->getCurrentPageResults();
     }
 
     /**

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -336,10 +336,12 @@ class ModelManager implements ModelManagerInterface
      */
     public function getModelIdentifier($class)
     {
-        @trigger_error(sprintf(
-            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.6 and will be removed in version 4.0.',
-            __METHOD__
-        ), E_USER_DEPRECATED);
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.6 and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
 
         return $this->getMetadata($class, 'sonata_deprecation_mute')->identifier;
     }
@@ -532,14 +534,16 @@ class ModelManager implements ModelManagerInterface
      */
     public function getDefaultSortValues($class)
     {
-        @trigger_error(sprintf(
-            'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.6 and will be removed in version 4.0.',
-            __METHOD__
-        ), E_USER_DEPRECATED);
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'Method %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.6 and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
 
         return [
             '_sort_order' => 'ASC',
-            '_sort_by' => $this->getModelIdentifier($class),
+            '_sort_by' => $this->getModelIdentifier($class, 'sonata_deprecation_mute'),
             '_page' => 1,
             '_per_page' => 25,
         ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This PR deprecates `Pager::getResults` in favor of `getCurrentPageResults`. It also avoids triggering some deprecations in `ModelManager`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added implementation of `Pager::getCurrentPageResults()` method.
### Deprecated
- Deprecated `Pager::getResults()` method in favor of `Pager::getCurrentPageResults()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
