### PR TITLE
Add ProxyQueryInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,15 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\Filter\Filter
+
+Deprecate passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`
+which is not an instance of `Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface` as
+argument 1 to the `Sonata\DoctrineMongoDBAdminBundle\Filter\Filter::filter()` method.
+
+UPGRADE FROM 3.6 to 3.7
+=======================
+
 ### Sonata\DoctrineMongoDBAdminBundle\Datagrid\Pager
 
 Deprecated `computeNbResult()` method.

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,4 +9,12 @@
     <plugins>
         <pluginClass class="Psalm\SymfonyPsalmPlugin\Plugin"/>
     </plugins>
+    <issueHandlers>
+        <!-- TODO: This will be fixed when regex would allow as an expression -->
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <file name="src/Filter/StringFilter.php"/>
+            </errorLevel>
+        </InvalidArgument>
+    </issueHandlers>
 </psalm>

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Datagrid;
 
 use Doctrine\ODM\MongoDB\Query\Builder;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * This class try to unify the query usage with Doctrine.

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Datagrid;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
+
+interface ProxyQueryInterface extends BaseProxyQueryInterface
+{
+    /**
+     * @return Builder
+     */
+    public function getQueryBuilder();
+}

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -13,12 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 abstract class AbstractDateFilter extends Filter
 {
@@ -41,8 +42,19 @@ abstract class AbstractDateFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         //check data sanity
         if (true !== \is_array($data)) {
             return;
@@ -123,17 +135,17 @@ abstract class AbstractDateFilter extends Filter
     /**
      * @return void
      */
-    abstract protected function applyTypeIsLessEqual(ProxyQueryInterface $query, string $field, array $data);
+    abstract protected function applyTypeIsLessEqual(BaseProxyQueryInterface $query, string $field, array $data);
 
     /**
      * @return void
      */
-    abstract protected function applyTypeIsGreaterThan(ProxyQueryInterface $query, string $field, array $data);
+    abstract protected function applyTypeIsGreaterThan(BaseProxyQueryInterface $query, string $field, array $data);
 
     /**
      * @return void
      */
-    abstract protected function applyTypeIsEqual(ProxyQueryInterface $query, string $field, array $data);
+    abstract protected function applyTypeIsEqual(BaseProxyQueryInterface $query, string $field, array $data);
 
     /**
      * @param string    $operation
@@ -142,9 +154,20 @@ abstract class AbstractDateFilter extends Filter
      *
      * @return void
      */
-    protected function applyType(ProxyQueryInterface $query, $operation, $field, ?\DateTime $datetime = null)
+    protected function applyType(BaseProxyQueryInterface $query, $operation, $field, ?\DateTime $datetime = null)
     {
-        $query->field($field)->$operation($datetime);
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
+        $query->getQueryBuilder()->field($field)->$operation($datetime);
         $this->active = true;
     }
 

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\Form\Type\BooleanType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
@@ -28,8 +29,19 @@ class BooleanFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
@@ -48,7 +60,7 @@ class BooleanFilter extends Filter
                 return;
             }
 
-            $query->field($field)->in($values);
+            $query->getQueryBuilder()->field($field)->in($values);
             $this->active = true;
         } else {
             if (!\in_array($data['value'], [BooleanType::TYPE_NO, BooleanType::TYPE_YES], true)) {
@@ -57,7 +69,7 @@ class BooleanFilter extends Filter
 
             $data = BooleanType::TYPE_YES === $data['value'];
 
-            $query->field($field)->equals($data);
+            $query->getQueryBuilder()->field($field)->equals($data);
             $this->active = true;
         }
     }

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -13,8 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -28,8 +29,19 @@ class CallbackFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!\is_callable($this->getOption('callback'))) {
             throw new \RuntimeException(sprintf(
                 'Please provide a valid callback option "filter" for field "%s"',

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
@@ -28,11 +29,24 @@ class ChoiceFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {
             return;
         }
+
+        $queryBuilder = $query->getQueryBuilder();
 
         if (\is_array($data['value'])) {
             if (0 === \count($data['value'])) {
@@ -44,9 +58,9 @@ class ChoiceFilter extends Filter
             }
 
             if (ContainsOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
-                $query->field($field)->notIn($data['value']);
+                $queryBuilder->field($field)->notIn($data['value']);
             } else {
-                $query->field($field)->in($data['value']);
+                $queryBuilder->field($field)->in($data['value']);
             }
 
             $this->active = true;
@@ -56,9 +70,9 @@ class ChoiceFilter extends Filter
             }
 
             if (ContainsOperatorType::TYPE_NOT_CONTAINS === $data['type']) {
-                $query->field($field)->notEqual($data['value']);
+                $queryBuilder->field($field)->notEqual($data['value']);
             } else {
-                $query->field($field)->equals($data['value']);
+                $queryBuilder->field($field)->equals($data['value']);
             }
 
             $this->active = true;

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 /**
@@ -30,7 +31,7 @@ class DateFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsLessEqual(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsLessEqual(BaseProxyQueryInterface $query, $field, $data)
     {
         $data['value']->add(new \DateInterval('P1D'));
 
@@ -41,7 +42,7 @@ class DateFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsGreaterThan(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsGreaterThan(BaseProxyQueryInterface $query, $field, $data)
     {
         $data['value']->add(new \DateInterval('P1D'));
 
@@ -56,11 +57,22 @@ class DateFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsEqual(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsEqual(BaseProxyQueryInterface $query, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         $end = clone $data['value'];
         $end->add(new \DateInterval('P1D'));
 
-        $query->field($field)->range($data['value'], $end);
+        $query->getQueryBuilder()->field($field)->range($data['value'], $end);
     }
 }

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 /**
@@ -37,7 +38,7 @@ class DateTimeFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsLessEqual(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsLessEqual(BaseProxyQueryInterface $query, $field, $data)
     {
         // Add a minute so less then equal selects all seconds.
         $data['value']->add(new \DateInterval('PT1M'));
@@ -49,7 +50,7 @@ class DateTimeFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsGreaterThan(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsGreaterThan(BaseProxyQueryInterface $query, $field, $data)
     {
         // Add 59 seconds so anything above the minute is selected
         $data['value']->add(new \DateInterval('PT59S'));
@@ -63,8 +64,19 @@ class DateTimeFilter extends AbstractDateFilter
      * @param string $field
      * @param array  $data
      */
-    protected function applyTypeIsEqual(ProxyQueryInterface $query, $field, $data)
+    protected function applyTypeIsEqual(BaseProxyQueryInterface $query, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         /** @var \DateTime $end */
         $end = clone $data['value'];
         $end->add(new \DateInterval('PT1M'));

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -16,6 +16,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 // NEXT MAJOR: Uncomment next line.
 // use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter as BaseFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 abstract class Filter extends BaseFilter
 {
@@ -29,6 +30,19 @@ abstract class Filter extends BaseFilter
      */
     public function apply($query, $filterData)
     {
+        if (!$query instanceof ProxyQueryInterface) {
+            /* NEXT_MAJOR: Remove this deprecation and uncomment the error */
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+
+            // throw new \TypeError(sprintf('The query MUST implement "%s".', ProxyQueryInterface::class));
+        }
+
         // NEXT_MAJOR: Remove next line.
         $this->value = $filterData;
 

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
@@ -35,8 +36,19 @@ class NumberFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || !is_numeric($data['value'])) {
             return;
         }
@@ -45,7 +57,7 @@ class NumberFilter extends Filter
 
         $operator = $this->getOperator((int) $type);
 
-        $query->field($field)->$operator((float) $data['value']);
+        $query->getQueryBuilder()->field($field)->$operator((float) $data['value']);
         $this->active = true;
     }
 

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
 use MongoDB\BSON\Regex;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
@@ -28,8 +29,19 @@ class StringFilter extends Filter
      *
      * @return void
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $data)
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data)
     {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ));
+        }
+
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || null === $data['value']) {
             return;
         }
@@ -42,7 +54,7 @@ class StringFilter extends Filter
 
         $data['type'] = isset($data['type']) && !empty($data['type']) ? $data['type'] : ContainsOperatorType::TYPE_CONTAINS;
 
-        $obj = $query;
+        $obj = $query->getQueryBuilder();
         if (self::CONDITION_OR === $this->condition) {
             $obj = $query->expr();
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Similar at what was done in the ORM.

Ref: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1218

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `ProxyQueryInterface` to use it as a type declaration.
### Deprecated
- Deprecated calling `Filter::apply` with an instance not implementing `ProxyQueryInterface`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
