### PR TITLE
Show embedded value in admin list

### DIFF
--- a/tests/App/Admin/AuthorAdmin.php
+++ b/tests/App/Admin/AuthorAdmin.php
@@ -27,7 +27,8 @@ final class AuthorAdmin extends AbstractAdmin
     {
         $list
             ->add('id')
-            ->addIdentifier('name');
+            ->addIdentifier('name')
+            ->addIdentifier('address.street');
     }
 
     protected function configureDatagridFilters(DatagridMapper $filter): void


### PR DESCRIPTION
Ref: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/issues/545

Apparently it fails in `master` branch, with this we'll make sure it works.