### PR TITLE
Add reverseTransform method and remove field description code option calls

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager
+
+Deprecated `modelReverseTransform()` method, use `reverseTransform()` instead.
+
 ### Sonata\DoctrineMongoDBAdminBundle\Filter\Filter
 
 Deprecate passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.89",
+        "sonata-project/admin-bundle": "^3.93",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -114,7 +114,6 @@ class DatagridBuilder implements DatagridBuilderInterface
         //    $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
         //}
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
 
         if (\in_array($fieldDescription->getMappingType(), [ClassMetadata::ONE, ClassMetadata::MANY], true)) {

--- a/src/Builder/ListBuilder.php
+++ b/src/Builder/ListBuilder.php
@@ -120,7 +120,6 @@ class ListBuilder implements ListBuilderInterface
             throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('label', $fieldDescription->getOption('label', $fieldDescription->getName()));
 
         if (!$fieldDescription->getTemplate()) {
@@ -165,10 +164,6 @@ class ListBuilder implements ListBuilderInterface
 
         if (null === $fieldDescription->getOption('name')) {
             $fieldDescription->setOption('name', 'Action');
-        }
-
-        if (null === $fieldDescription->getOption('code')) {
-            $fieldDescription->setOption('code', 'Action');
         }
 
         if (null !== $fieldDescription->getOption('actions')) {

--- a/src/Builder/ShowBuilder.php
+++ b/src/Builder/ShowBuilder.php
@@ -90,7 +90,6 @@ class ShowBuilder implements ShowBuilderInterface
             throw new \RuntimeException(sprintf('Please define a type for field `%s` in `%s`', $fieldDescription->getName(), \get_class($admin)));
         }
 
-        $fieldDescription->setOption('code', $fieldDescription->getOption('code', $fieldDescription->getName()));
         $fieldDescription->setOption('label', $fieldDescription->getOption('label', $fieldDescription->getName()));
 
         if (!$fieldDescription->getTemplate()) {

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -582,8 +582,31 @@ class ModelManager implements ModelManagerInterface
         return $instance;
     }
 
+    public function reverseTransform(object $object, array $array = []): void
+    {
+        // NEXT_MAJOR: Remove 'sonata_deprecation_mute' argument.
+        $metadata = $this->getMetadata(\get_class($object), 'sonata_deprecation_mute');
+
+        foreach ($array as $name => $value) {
+            $property = $this->getFieldName($metadata, $name);
+
+            $this->propertyAccessor->setValue($instance, $property, $value);
+        }
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x, use reverseTransform() instead.
+     */
     public function modelReverseTransform($class, array $array = [])
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use "reverseTransform()" instead.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
         $instance = $this->getModelInstance($class);
         // NEXT_MAJOR: Remove 'sonata_deprecation_mute' argument.
         $metadata = $this->getMetadata($class, 'sonata_deprecation_mute');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This updates some code to be updated with some of the latest `sonata-project/admin-bundle` changes.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ModelManager::reverseTransform()` method.
### Deprecated
- Deprecated `ModelManager::modelReverseTransform()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
