### PR TITLE
Fix argument 2 for trigger_error

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -45,7 +45,7 @@ class Pager extends BasePager
 
         @trigger_error(sprintf(
             'Relying on the protected property "%s::$nbResults" and its getter/setter is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.7 and will fail 4.0. Use "countResults()" and "setResultsCount()" instead.',
-            self::class,
+            self::class
         ), \E_USER_DEPRECATED);
 
         return $deprecatedCount;
@@ -63,7 +63,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.7 and will be removed in 4.0. Use "countResults()" instead.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 
@@ -82,7 +82,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.7 and will be removed in 4.0.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 
@@ -104,7 +104,7 @@ class Pager extends BasePager
         @trigger_error(sprintf(
             'Method "%s()" is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.7 and will'
         .' be removed in 4.0. Use "getCurrentPageResults()" instead.',
-            __METHOD__,
+            __METHOD__
         ), \E_USER_DEPRECATED);
 
         return $this->getCurrentPageResults();
@@ -154,7 +154,7 @@ class Pager extends BasePager
         if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
             @trigger_error(sprintf(
                 'The %s() method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.7 and will be removed in 4.0. Use "setResultsCount()" instead.',
-                __METHOD__,
+                __METHOD__
             ), \E_USER_DEPRECATED);
         }
 

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -52,7 +52,7 @@ abstract class AbstractDateFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         //check data sanity
@@ -164,7 +164,7 @@ abstract class AbstractDateFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $query->getQueryBuilder()->field($field)->$operation($datetime);

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -39,7 +39,7 @@ class BooleanFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -39,7 +39,7 @@ class CallbackFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!\is_callable($this->getOption('callback'))) {

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -39,7 +39,7 @@ class ChoiceFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('type', $data) || !\array_key_exists('value', $data)) {

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -67,7 +67,7 @@ class DateFilter extends AbstractDateFilter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         $end = clone $data['value'];

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -74,7 +74,7 @@ class DateTimeFilter extends AbstractDateFilter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         /** @var \DateTime $end */

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -38,7 +38,7 @@ abstract class Filter extends BaseFilter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
 
             // throw new \TypeError(sprintf('The query MUST implement "%s".', ProxyQueryInterface::class));
         }

--- a/src/Filter/ModelFilter.php
+++ b/src/Filter/ModelFilter.php
@@ -43,7 +43,7 @@ class ModelFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data)) {

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -46,7 +46,7 @@ class NumberFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || !is_numeric($data['value'])) {

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -39,7 +39,7 @@ class StringFilter extends Filter
                 \get_class($query),
                 __METHOD__,
                 ProxyQueryInterface::class
-            ));
+            ), \E_USER_DEPRECATED);
         }
 
         if (!$data || !\is_array($data) || !\array_key_exists('value', $data) || null === $data['value']) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fix missing argument 2 in `trigger_error` and removes some trailing comma in function calls.
Similar to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1365
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Missing argument 2 in calls to `trigger_error()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
