### PR TITLE
Add support for sorting embedded fields

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -93,7 +93,13 @@ class ProxyQuery implements ProxyQueryInterface
 
     public function setSortBy($parentAssociationMappings, $fieldMapping)
     {
-        $this->sortBy = $fieldMapping['fieldName'];
+        $parents = '';
+
+        foreach ($parentAssociationMappings as $mapping) {
+            $parents .= $mapping['fieldName'].'.';
+        }
+
+        $this->sortBy = $parents.$fieldMapping['fieldName'];
 
         return $this;
     }

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -132,10 +132,10 @@ final class DatagridBuilderTest extends AbstractModelManagerTestCase
         $classMetadata = $this->getMetadataForDocumentWithAnnotations($documentClass);
 
         $fieldDescription = new FieldDescription(
-            'associatedDocument',
+            'embeddedDocument',
             [],
-            $classMetadata->fieldMappings['associatedDocument'],
-            $classMetadata->associationMappings['associatedDocument']
+            $classMetadata->fieldMappings['embeddedDocument'],
+            $classMetadata->associationMappings['embeddedDocument']
         );
 
         $this->admin
@@ -157,7 +157,7 @@ final class DatagridBuilderTest extends AbstractModelManagerTestCase
 
         $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
-        $this->assertSame($classMetadata->associationMappings['associatedDocument'], $fieldDescription->getOption('association_mapping'));
+        $this->assertSame($classMetadata->associationMappings['embeddedDocument'], $fieldDescription->getOption('association_mapping'));
     }
 
     public function testAddFilterNoType(): void

--- a/tests/Builder/FormContractorTest.php
+++ b/tests/Builder/FormContractorTest.php
@@ -177,14 +177,14 @@ class FormContractorTest extends AbstractModelManagerTestCase
         $admin->method('getModelManager')->willReturn($this->modelManager);
 
         $fieldDescription = new FieldDescription(
-            'associatedDocument',
+            'embeddedDocument',
             [],
-            $classMetadata->fieldMappings['associatedDocument'],
-            $classMetadata->associationMappings['associatedDocument']
+            $classMetadata->fieldMappings['embeddedDocument'],
+            $classMetadata->associationMappings['embeddedDocument']
         );
 
         $this->formContractor->fixFieldDescription($admin, $fieldDescription);
 
-        $this->assertSame($classMetadata->associationMappings['associatedDocument'], $fieldDescription->getAssociationMapping());
+        $this->assertSame($classMetadata->associationMappings['embeddedDocument'], $fieldDescription->getAssociationMapping());
     }
 }

--- a/tests/Builder/ListBuilderTest.php
+++ b/tests/Builder/ListBuilderTest.php
@@ -179,11 +179,11 @@ class ListBuilderTest extends AbstractModelManagerTestCase
     {
         return [
             'one-to-one' => [
-                'associatedDocument',
+                'embeddedDocument',
                 '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig',
             ],
             'many-to-one' => [
-                'embeddedDocument',
+                'embeddedDocuments',
                 '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig',
             ],
         ];

--- a/tests/Builder/ShowBuilderTest.php
+++ b/tests/Builder/ShowBuilderTest.php
@@ -146,12 +146,12 @@ final class ShowBuilderTest extends AbstractModelManagerTestCase
         return [
             'one' => [
                 FieldDescriptionInterface::TYPE_MANY_TO_ONE,
-                'associatedDocument',
+                'embeddedDocument',
                 '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
             ],
             'many' => [
                 FieldDescriptionInterface::TYPE_MANY_TO_MANY,
-                'embeddedDocument',
+                'embeddedDocuments',
                 '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
             ],
         ];

--- a/tests/Datagrid/ProxyQueryTest.php
+++ b/tests/Datagrid/ProxyQueryTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\DocumentWithReferences;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\Fixtures\Document\EmbeddedDocument;
 
 final class ProxyQueryTest extends TestCase
 {
@@ -93,6 +94,19 @@ final class ProxyQueryTest extends TestCase
         );
     }
 
+    public function testSortingWithWithEmbedded(): void
+    {
+        $queryBuilder = $this->dm->createQueryBuilder(DocumentWithReferences::class);
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+        $proxyQuery->setSortBy([['fieldName' => 'embeddedDocument']], ['fieldName' => 'position']);
+
+        $this->assertSame(
+            'embeddedDocument.position',
+            $proxyQuery->getSortBy()
+        );
+    }
+
     /**
      * NEXT_MAJOR: Remove the legacy group and the "doesNotPerformAssertions".
      *
@@ -135,13 +149,40 @@ final class ProxyQueryTest extends TestCase
         $proxyQuery->setSortBy([], ['fieldName' => 'name']);
         $proxyQuery->setSortOrder('DESC');
 
-        $result = $proxyQuery->execute();
+        $this->assertSame(['B', 'A'], $this->getNames($proxyQuery->execute()->toArray()));
+    }
 
-        $names = array_map(static function (array $result) {
+    public function testExecuteAllowsSortingWithEmbedded(): void
+    {
+        $documentA = new DocumentWithReferences('A', new EmbeddedDocument(1));
+        $documentB = new DocumentWithReferences('B', new EmbeddedDocument(2));
+
+        $this->dm->persist($documentA);
+        $this->dm->persist($documentB);
+        $this->dm->flush();
+
+        $queryBuilder = $this->dm->createQueryBuilder(DocumentWithReferences::class);
+        $queryBuilder
+            ->select(['name'])
+            ->hydrate(false);
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+        $proxyQuery->setSortBy([['fieldName' => 'embeddedDocument']], ['fieldName' => 'position']);
+        $proxyQuery->setSortOrder('DESC');
+
+        $this->assertSame(['B', 'A'], $this->getNames($proxyQuery->execute()->toArray()));
+    }
+
+    /**
+     * @param array{array{name: string}} $results
+     *
+     * @return string[]
+     */
+    private function getNames(array $results): array
+    {
+        return array_values(array_map(static function (array $result) {
             return $result['name'];
-        }, $result->toArray());
-
-        $this->assertSame(['B', 'A'], array_values($names));
+        }, $results));
     }
 
     private function createConfiguration(): Configuration

--- a/tests/Fixtures/Document/DocumentWithReferences.php
+++ b/tests/Fixtures/Document/DocumentWithReferences.php
@@ -27,20 +27,21 @@ class DocumentWithReferences
     /**
      * @ODM\EmbedOne()
      */
-    private $associatedDocument;
+    private $embeddedDocument;
 
     /**
      * @ODM\EmbedMany()
      */
-    private $embeddedDocument;
+    private $embeddedDocuments;
 
     /**
      * @ODM\ReferenceOne(targetDocument=TestDocument::class)
      */
     private $referenceOne;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?EmbeddedDocument $embeddedDocument = null)
     {
         $this->name = $name;
+        $this->embeddedDocument = $embeddedDocument;
     }
 }

--- a/tests/Fixtures/Document/EmbeddedDocument.php
+++ b/tests/Fixtures/Document/EmbeddedDocument.php
@@ -21,9 +21,20 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 class EmbeddedDocument
 {
     /**
+     * @ODM\Field(type="int")
+     *
+     * @var int
+     */
+    public $position;
+    /**
      * @ODM\Field(type="bool")
      *
      * @var bool
      */
     private $plainField;
+
+    public function __construct(int $position = 0)
+    {
+        $this->position = $position;
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Follow-up of https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/213 with tests.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for sorting embbeded fields in lists.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
