### PR TITLE
Add deprecations to some ModelManager methods

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -46,6 +46,7 @@ argument 2 to the `Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager::addIden
 Deprecated passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`
 which is not an instance of `Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface` as
 argument 2 to the `Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager::batchDelete()` method.
+Deprecated `getModelInstance()` method.
 
 ### Sonata\DoctrineMongoDBAdminBundle\Filter\Filter
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -40,6 +40,12 @@ This class has been deprecated without replacement.
 
 Deprecated `getParentMetadataForProperty()` method.
 Deprecated `getNewFieldDescriptionInstance()` method, you SHOULD use `FieldDescriptionFactory::create()` instead.
+Deprecated passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`
+which is not an instance of `Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface` as
+argument 2 to the `Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager::addIdentifiersToQuery()` method.
+Deprecated passing an instance of `Sonata\AdminBundle\Datagrid\ProxyQueryInterface`
+which is not an instance of `Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface` as
+argument 2 to the `Sonata\DoctrineMongoDBAdminBundle\Model\ModelManager::batchDelete()` method.
 
 ### Sonata\DoctrineMongoDBAdminBundle\Filter\Filter
 

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -507,8 +507,22 @@ class ModelManager implements ModelManagerInterface
         return $metadata->getFieldNames();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and will be removed in version 4.0.
+     */
     public function getModelInstance($class)
     {
+        // NEXT_MAJOR: Remove this block.
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x and'
+                .' will be removed in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if (!class_exists($class)) {
             throw new \InvalidArgumentException(sprintf('Class "%s" not found', $class));
         }

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -19,10 +19,11 @@ use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrineMongoDBAdminBundle\FieldDescription\FieldDescription;
 use Sonata\Exporter\Source\DoctrineODMQuerySourceIterator;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
@@ -427,8 +428,21 @@ class ModelManager implements ModelManagerInterface
     /**
      * @return void
      */
-    public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx)
+    public function addIdentifiersToQuery($class, BaseProxyQueryInterface $query, array $idx)
     {
+        if (!$query instanceof ProxyQueryInterface) {
+            // NEXT_MAJOR: Remove this deprecation and throw the exception
+            @trigger_error(sprintf(
+                'Passing %s as argument 2 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                \TypeError::class,
+                BaseProxyQueryInterface::class
+            ), \E_USER_DEPRECATED);
+            // throw new \TypeError(sprintf('The query MUST implement %s.', ProxyQueryInterface::class));
+        }
+
         $queryBuilder = $query->getQueryBuilder();
         $queryBuilder->field('_id')->in($idx);
     }
@@ -436,8 +450,21 @@ class ModelManager implements ModelManagerInterface
     /**
      * @return void
      */
-    public function batchDelete($class, ProxyQueryInterface $query)
+    public function batchDelete($class, BaseProxyQueryInterface $query)
     {
+        if (!$query instanceof ProxyQueryInterface) {
+            // NEXT_MAJOR: Remove this deprecation and throw the exception
+            @trigger_error(sprintf(
+                'Passing %s as argument 2 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x'
+                .' and will throw a %s error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                \TypeError::class,
+                BaseProxyQueryInterface::class
+            ), \E_USER_DEPRECATED);
+            // throw new \TypeError(sprintf('The query MUST implement %s.', ProxyQueryInterface::class));
+        }
+
         /** @var Query $queryBuilder */
         $queryBuilder = $query->getQueryBuilder()->getQuery();
 

--- a/tests/Model/ModelManagerTest.php
+++ b/tests/Model/ModelManagerTest.php
@@ -405,6 +405,11 @@ final class ModelManagerTest extends TestCase
         $this->assertSame($name, $result['filter']['_sort_by']);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetModelInstanceException(): void
     {
         $model = new ModelManager($this->registry, $this->propertyAccessor);
@@ -414,6 +419,11 @@ final class ModelManagerTest extends TestCase
         $model->getModelInstance(AbstractDocument::class);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetModelInstanceForProtectedDocument(): void
     {
         $model = new ModelManager($this->registry, $this->propertyAccessor);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
`ModelManagerInterface::getModelInstance` is deprecated in `sonata-project/admin-bundle`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `ModelManager::getModelInstance()` method.
- Deprecated not passing an instance of `ProxyQueryInterface` to `ModelManager::addIdentifiersToQuery()` method.
- Deprecated not passing an instance of `ProxyQueryInterface` to `ModelManager::batchDelete()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
