### PR TITLE
Bump panther and use it when is needed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "psalm/plugin-symfony": "^2.0",
         "symfony/browser-kit": "^4.4 || ^5.1",
         "symfony/css-selector": "^4.4 || ^5.1",
-        "symfony/panther": "^0.9.0",
+        "symfony/panther": "^1.0",
         "symfony/phpunit-bridge": "^5.1.8",
         "vimeo/psalm": "^4.1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.95",
+        "sonata-project/admin-bundle": "^3.96",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/tests/App/DataFixtures/MongoDB/BookFixtures.php
+++ b/tests/App/DataFixtures/MongoDB/BookFixtures.php
@@ -16,14 +16,25 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\App\DataFixtures\MongoDB;
 use Doctrine\Bundle\MongoDBBundle\Fixture\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Author;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Book;
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Category;
 
 final class BookFixtures extends Fixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {
-        $book = new Book('book_id', 'Don Quixote', $this->getReference(AuthorFixtures::AUTHOR));
-        $book->addCategory($this->getReference(CategoryFixtures::CATEGORY));
+        $author = $this->getReference(AuthorFixtures::AUTHOR);
+
+        \assert($author instanceof Author);
+
+        $book = new Book('book_id', 'Don Quixote', $author);
+
+        $category = $this->getReference(CategoryFixtures::CATEGORY);
+
+        \assert($category instanceof Category);
+
+        $book->addCategory($category);
 
         $manager->persist($book);
         $manager->flush();

--- a/tests/Functional/BaseFunctionalTestCase.php
+++ b/tests/Functional/BaseFunctionalTestCase.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Functional;
+
+use Sonata\DoctrineMongoDBAdminBundle\Tests\App\AppKernel;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+abstract class BaseFunctionalTestCase extends WebTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->client->followRedirects();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return AppKernel::class;
+    }
+}

--- a/tests/Functional/CRUDTest.php
+++ b/tests/Functional/CRUDTest.php
@@ -16,22 +16,8 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Functional;
 use Sonata\DoctrineMongoDBAdminBundle\Tests\App\Document\Category;
 use Symfony\Component\HttpFoundation\Request;
 
-final class CRUDTest extends BasePantherTestCase
+final class CRUDTest extends BaseFunctionalTestCase
 {
-    public function testFilter(): void
-    {
-        $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/list');
-
-        $this->client->clickLink('Filters');
-        $this->client->clickLink('Name');
-
-        $this->client->submitForm('Filter', [
-            'filter[name][value]' => 'Novel',
-        ]);
-
-        self::assertSelectorTextContains('.sonata-link-identifier', 'Novel');
-    }
-
     public function testList(): void
     {
         $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/list');

--- a/tests/Functional/DatagridTest.php
+++ b/tests/Functional/DatagridTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final class DatagridTest extends BasePantherTestCase
+{
+    public function testFilter(): void
+    {
+        $this->client->request(Request::METHOD_GET, '/admin/tests/app/category/list');
+
+        $this->client->clickLink('Filters');
+        $this->client->clickLink('Name');
+
+        $this->client->submitForm('Filter', [
+            'filter[name][value]' => 'Dystopian',
+        ]);
+
+        self::assertSelectorTextContains('.sonata-link-identifier', 'Dystopian');
+    }
+}


### PR DESCRIPTION
@dmaicher mentioned it somewhere, for CRUD operations we don't need `symfony/panther`.