### PR TITLE
fix form and filter template registration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.96",
+        "sonata-project/admin-bundle": "^3.98.2",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddGuesserCompilerPass.php
@@ -18,7 +18,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @internal since sonata-project/doctrine-mongodb-admin-bundle version 4.0
  *
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
  */

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -15,9 +15,14 @@ namespace Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @internal since sonata-project/doctrine-mongodb-admin-bundle version 4.0
  *
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
  */
@@ -34,15 +39,46 @@ class AddTemplatesCompilerPass implements CompilerPassInterface
             }
 
             $definition = $container->getDefinition($id);
+            // NEXT_MAJOR: Remove this line.
             $templates = $container->getParameter('sonata_doctrine_mongodb_admin.templates');
 
-            if (!$definition->hasMethodCall('setFormTheme')) {
-                $definition->addMethodCall('setFormTheme', [$templates['form']]);
-            }
+            // NEXT_MAJOR: Remove this line and uncomment the following
+            $this->mergeMethodCall($definition, 'setFormTheme', $templates['form']);
+//          $this->mergeMethodCall($definition, 'setFormTheme', ['@SonataDoctrineMongoDBAdmin/Form/form_admin_fields.html.twig']);
 
-            if (!$definition->hasMethodCall('setFilterTheme')) {
-                $definition->addMethodCall('setFilterTheme', [$templates['filter']]);
+            // NEXT_MAJOR: Remove this line and uncomment the following
+            $this->mergeMethodCall($definition, 'setFilterTheme', $templates['filter']);
+//          $this->mergeMethodCall($definition, 'setFilterTheme', ['@SonataDoctrineMongoDBAdmin/Form/filter_admin_fields.html.twig']);
+        }
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function mergeMethodCall(Definition $definition, string $name, array $value): void
+    {
+        if (!$definition->hasMethodCall($name)) {
+            $definition->addMethodCall($name, [$value]);
+
+            return;
+        }
+
+        $methodCalls = $definition->getMethodCalls();
+
+        foreach ($methodCalls as &$calls) {
+            foreach ($calls as &$call) {
+                if (\is_string($call)) {
+                    if ($call !== $name) {
+                        continue 2;
+                    }
+
+                    continue;
+                }
+
+                $call = [array_merge($call[0], $value)];
             }
         }
+
+        $definition->setMethodCalls($methodCalls);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,11 +44,15 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('templates')
                     ->addDefaultsIfNotSet()
                     ->children()
+                        // NEXT_MAJOR: Remove this option.
                         ->arrayNode('form')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineMongoDBAdmin/Form/form_admin_fields.html.twig'])
                         ->end()
+                        // NEXT_MAJOR: Remove this option.
                         ->arrayNode('filter')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x.')
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineMongoDBAdmin/Form/filter_admin_fields.html.twig'])
                         ->end()

--- a/src/SonataDoctrineMongoDBAdminBundle.php
+++ b/src/SonataDoctrineMongoDBAdminBundle.php
@@ -15,6 +15,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle;
 
 use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
 use Sonata\DoctrineMongoDBAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,6 +30,6 @@ class SonataDoctrineMongoDBAdminBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new AddGuesserCompilerPass());
-        $container->addCompilerPass(new AddTemplatesCompilerPass());
+        $container->addCompilerPass(new AddTemplatesCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
     }
 }

--- a/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddTemplatesCompilerPassTest.php
@@ -25,6 +25,8 @@ final class AddTemplatesCompilerPassTest extends AbstractCompilerPassTestCase
         $adminServiceId = 'admin_id';
         $adminService = new Definition();
         $adminService->addTag('sonata.admin', ['manager_type' => 'doctrine_mongodb']);
+        $adminService->addMethodCall('setFormTheme', [['foo.html.twig']]);
+        $adminService->addMethodCall('setFilterTheme', [['bar.html.twig']]);
         $this->setDefinition($adminServiceId, $adminService);
 
         $adminServiceNotManagedId = 'admin_not_managed_id';
@@ -32,17 +34,21 @@ final class AddTemplatesCompilerPassTest extends AbstractCompilerPassTestCase
         $adminServiceNotManaged->addTag('sonata.admin', ['manager_type' => 'type']);
         $this->setDefinition($adminServiceNotManagedId, $adminServiceNotManaged);
 
+        // NEXT_MAJOR: remove those 2 variables
         $formTemplates = [
             'form.html.twig',
         ];
         $filterTemplates = [
             'filter.html.twig',
         ];
+
+        // NEXT_MAJOR: remove this variable
         $templates = [
             'form' => $formTemplates,
             'filter' => $filterTemplates,
         ];
 
+        // NEXT_MAJOR: remove this line
         $this->setParameter('sonata_doctrine_mongodb_admin.templates', $templates);
 
         $this->compile();
@@ -51,7 +57,10 @@ final class AddTemplatesCompilerPassTest extends AbstractCompilerPassTestCase
             $adminServiceId,
             'setFormTheme',
             [
-                $formTemplates,
+                // NEXT_MAJOR: remove this line
+                array_merge(['foo.html.twig'], $formTemplates),
+                // NEXT_MAJOR: uncomment this line
+                //['foo.html.twig', '@SonataDoctrineMongoDBAdmin/Form/form_admin_fields.html.twig'],
             ]
         );
 
@@ -59,7 +68,10 @@ final class AddTemplatesCompilerPassTest extends AbstractCompilerPassTestCase
             $adminServiceId,
             'setFilterTheme',
             [
-                $filterTemplates,
+                // NEXT_MAJOR: remove this line
+                array_merge(['bar.html.twig'], $filterTemplates),
+                // NEXT_MAJOR: uncomment this line
+                //['bar.html.twig', '@SonataDoctrineMongoDBAdmin/Form/filter_admin_fields.html.twig'],
             ]
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #583 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `templates.form` and `templates.filter` config

### Fixed
- Always merge form and filter templates with existing method calls
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
