### PR TITLE
Filter by Id

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.0",
         "doctrine/persistence": "^1.3.4 || ^2.0",
-        "sonata-project/admin-bundle": "^3.98.2",
+        "sonata-project/admin-bundle": "^3.99",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "symfony/config": "^4.4",
         "symfony/dependency-injection": "^4.4",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14,6 +14,7 @@ parameters:
                 - src/Filter/ChoiceFilter.php
                 - src/Filter/DateFilter.php
                 - src/Filter/DateTimeFilter.php
+                - src/Filter/IdFilter.php
                 - src/Filter/ModelFilter.php
                 - src/Filter/NumberFilter.php
                 - src/Filter/StringFilter.php

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -46,13 +46,19 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         // NEXT_MAJOR: Remove this option.
                         ->arrayNode('form')
-                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x.')
+                            ->setDeprecated(
+                                'The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle'
+                                .' 3.x. Use "sonata_admin.templates.form_theme" instead.'
+                            )
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineMongoDBAdmin/Form/form_admin_fields.html.twig'])
                         ->end()
                         // NEXT_MAJOR: Remove this option.
                         ->arrayNode('filter')
-                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.x.')
+                            ->setDeprecated(
+                                'The "%node%" option is deprecated since sonata-project/doctrine-mongodb-admin-bundle'
+                                .'3.x. Use "sonata_admin.templates.filter_theme" instead.'
+                            )
                             ->prototype('scalar')->end()
                             ->defaultValue(['@SonataDoctrineMongoDBAdmin/Form/filter_admin_fields.html.twig'])
                         ->end()

--- a/src/FieldDescription/FilterTypeGuesser.php
+++ b/src/FieldDescription/FilterTypeGuesser.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\BooleanFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\IdFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\StringFilter;
@@ -286,6 +287,8 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
 
                 return new TypeGuess(StringFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case Type::ID:
+
+                return new TypeGuess(IdFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case Type::STRING:
                 $options['field_type'] = TextType::class;
 

--- a/src/Filter/IdFilter.php
+++ b/src/Filter/IdFilter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
+
+use MongoDB\BSON\ObjectId;
+use MongoDB\Driver\Exception\InvalidArgumentException;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class IdFilter extends Filter
+{
+    /**
+     * NEXT_MAJOR: Remove $alias parameter.
+     */
+    public function filter(BaseProxyQueryInterface $query, $alias, $field, $data): void
+    {
+        /* NEXT_MAJOR: Remove this deprecation and update the typehint */
+        if (!$query instanceof ProxyQueryInterface) {
+            @trigger_error(sprintf(
+                'Passing %s as argument 1 to %s() is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.8'
+                .' and will throw a \TypeError error in version 4.0. You MUST pass an instance of %s instead.',
+                \get_class($query),
+                __METHOD__,
+                ProxyQueryInterface::class
+            ), \E_USER_DEPRECATED);
+        }
+
+        if (!\array_key_exists('value', $data) || null === $data['value']) {
+            return;
+        }
+
+        $value = trim($data['value']);
+
+        if ('' === $value) {
+            return;
+        }
+
+        try {
+            $objectId = new ObjectId($value);
+        } catch (InvalidArgumentException $exception) {
+            return;
+        }
+
+        $type = $data['type'] ?? EqualOperatorType::TYPE_EQUAL;
+
+        if (EqualOperatorType::TYPE_EQUAL === $type) {
+            $query->getQueryBuilder()->field($field)->equals($objectId);
+        } else {
+            $query->getQueryBuilder()->field($field)->notEqual($objectId);
+        }
+
+        $this->active = true;
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return [
+            'field_type' => TextType::class,
+            'operator_type' => EqualOperatorType::class,
+        ];
+    }
+
+    public function getRenderSettings(): array
+    {
+        return [DefaultType::class, [
+            'field_type' => $this->getFieldType(),
+            'field_options' => $this->getFieldOptions(),
+            'operator_type' => $this->getOption('operator_type'),
+            'label' => $this->getLabel(),
+        ]];
+    }
+}

--- a/tests/FieldDescription/FilterTypeGuesserTest.php
+++ b/tests/FieldDescription/FilterTypeGuesserTest.php
@@ -24,6 +24,7 @@ use Sonata\DoctrineMongoDBAdminBundle\FieldDescription\FilterTypeGuesser;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\BooleanFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\IdFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\NumberFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\StringFilter;
@@ -191,6 +192,11 @@ final class FilterTypeGuesserTest extends RegistryTestCase
                 StringFilter::class,
                 Guess::MEDIUM_CONFIDENCE,
                 TextType::class,
+            ],
+            Type::ID => [
+                Type::ID,
+                IdFilter::class,
+                Guess::MEDIUM_CONFIDENCE,
             ],
             'text' => [
                 'text',

--- a/tests/Filter/IdFilterTest.php
+++ b/tests/Filter/IdFilterTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
+
+use MongoDB\BSON\ObjectId;
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\IdFilter;
+
+final class IdFilterTest extends FilterWithQueryBuilderTest
+{
+    /**
+     * @param mixed $value
+     *
+     * @dataProvider getNotApplicableValues
+     */
+    public function testEmpty($value): void
+    {
+        $filter = new IdFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->never())
+            ->method('field');
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, $value);
+
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @phpstan-return array<array{mixed}>
+     */
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [[]],
+        ];
+    }
+
+    public function testItDoesNotApplyWithWrongObjectId(): void
+    {
+        $filter = new IdFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        $queryBuilder = $this->getQueryBuilder();
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, ['value' => 'wrong_object_id', 'type' => null]);
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @dataProvider getEqualTypes
+     */
+    public function testDefaultTypeIsEquals(?int $type): void
+    {
+        $filter = new IdFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('equals')
+            ->with(new ObjectId('507f1f77bcf86cd799439011'));
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, ['value' => '507f1f77bcf86cd799439011', 'type' => $type]);
+
+        $this->assertTrue($filter->isActive());
+    }
+
+    /**
+     * @phpstan-return iterable<array{int|null}>
+     */
+    public function getEqualTypes(): iterable
+    {
+        yield 'default type' => [null];
+        yield 'equals type' => [EqualOperatorType::TYPE_EQUAL];
+    }
+
+    public function testNotEquals(): void
+    {
+        $filter = new IdFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('notEqual')
+            ->with(new ObjectId('507f1f77bcf86cd799439011'));
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, ['value' => '507f1f77bcf86cd799439011', 'type' => EqualOperatorType::TYPE_NOT_EQUAL]);
+        $this->assertTrue($filter->isActive());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When trying to filter by id, it does not work for mongodb since it should query using `ObjectId` instead of `string`. This PR adds a new `IdFilter` to be able to do that.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `IdFilter` to be able to filter by id in lists
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
