### PR TITLE
Add DateTimeRangeFilter and DateRangeFilter

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,6 +1,18 @@
 UPGRADE FROM 3.x to 4.0
 =======================
 
+### Sonata\DoctrineMongoDBAdminBundle\Filter\AbstractDateFilter
+
+This class has been refactored to support range queries, in order to do that the following protected methods have been
+removed:
+- `applyTypeIsLessEqual`
+- `applyTypeIsGreaterThan`
+- `applyTypeIsEqual`
+- `applyType`
+
+Prior to this change when filtering using a `DateFilter` or `DateTimeFilter` with `equals` type, it created a range
+query internally. Now you have to use `DateRangeFilter` or `DateTimeRangeFilter` and provide a range of dates.
+
 ### Sonata\DoctrineMongoDBAdminBundle\FieldDescription\TypeGuesser
 
 When guessing a `FieldDescriptionInterface` type with association mapping:

--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 
 abstract class AbstractDateFilter extends Filter
@@ -39,7 +40,9 @@ abstract class AbstractDateFilter extends Filter
 
     public function getDefaultOptions(): array
     {
-        return ['input_type' => 'datetime'];
+        return [
+            'field_type' => $this->getDateFieldType(),
+        ];
     }
 
     public function getRenderSettings(): array
@@ -61,57 +64,46 @@ abstract class AbstractDateFilter extends Filter
         ]];
     }
 
+    /**
+     * @phpstan-return class-string
+     */
+    abstract protected function getDateFieldType(): string;
+
     final protected function filter(ProxyQueryInterface $query, string $field, FilterData $data): void
     {
         if (!$data->hasValue() || null === $data->getValue()) {
             return;
         }
 
+        if ($this->range) {
+            $this->filterRange($query, $field, $data);
+
+            return;
+        }
+
+        $value = $data->getValue();
+
+        if (!$value instanceof \DateTimeInterface) {
+            return;
+        }
+
+        \assert($value instanceof \DateTime || $value instanceof \DateTimeImmutable);
+
         //default type for simple filter
         $type = $data->getType() ?? DateOperatorType::TYPE_EQUAL;
 
-        switch ($type) {
-            case DateOperatorType::TYPE_EQUAL:
-                $this->setActive(true);
+        // date filter should filter records for the whole day
+        if (false === $this->time && DateOperatorType::TYPE_EQUAL === $type) {
+            $endValue = clone $value;
+            $endValue = $endValue->add(new \DateInterval('P1D'));
 
-                $this->applyTypeIsEqual($query, $field, $data);
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_EQUAL), $field, $value);
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_THAN), $field, $endValue);
 
-                return;
-
-            case DateOperatorType::TYPE_GREATER_THAN:
-                $this->setActive(true);
-
-                $this->applyTypeIsGreaterThan($query, $field, $data);
-
-                return;
-
-            case DateOperatorType::TYPE_LESS_EQUAL:
-                $this->setActive(true);
-
-                $this->applyTypeIsLessEqual($query, $field, $data);
-
-                return;
-
-            case DateOperatorType::TYPE_GREATER_EQUAL:
-            case DateOperatorType::TYPE_LESS_THAN:
-                $this->setActive(true);
-
-                $this->applyType($query, $this->getOperator($type), $field, $data->getValue());
-
-                return;
+            return;
         }
-    }
 
-    abstract protected function applyTypeIsLessEqual(ProxyQueryInterface $query, string $field, FilterData $data): void;
-
-    abstract protected function applyTypeIsGreaterThan(ProxyQueryInterface $query, string $field, FilterData $data): void;
-
-    abstract protected function applyTypeIsEqual(ProxyQueryInterface $query, string $field, FilterData $data): void;
-
-    final protected function applyType(ProxyQueryInterface $query, string $operation, string $field, \DateTime $datetime): void
-    {
-        $query->getQueryBuilder()->field($field)->$operation($datetime);
-        $this->setActive(true);
+        $this->applyType($query, $this->getOperator($type), $field, $value);
     }
 
     /**
@@ -136,5 +128,58 @@ abstract class AbstractDateFilter extends Filter
         }
 
         return $choices[$type];
+    }
+
+    private function applyType(ProxyQueryInterface $queryBuilder, string $operation, string $field, \DateTimeInterface $value): void
+    {
+        $queryBuilder->getQueryBuilder()->field($field)->$operation($value);
+        $this->setActive(true);
+    }
+
+    private function filterRange(ProxyQueryInterface $query, string $field, FilterData $data): void
+    {
+        $value = $data->getValue();
+
+        // additional data check for ranged items
+        if (
+            !\is_array($value)
+            || !\array_key_exists('start', $value)
+            || !\array_key_exists('end', $value)
+        ) {
+            return;
+        }
+
+        if (
+            !$value['start'] instanceof \DateTimeInterface
+            && !$value['end'] instanceof \DateTimeInterface
+        ) {
+            return;
+        }
+
+        // date filter should filter records for the whole days
+        if (
+            false === $this->time
+            && ($value['end'] instanceof \DateTime || $value['end'] instanceof \DateTimeImmutable)
+        ) {
+            // since the received `\DateTime` object  uses the model timezone to represent
+            // the value submitted by the view (which can use a different timezone) and this
+            // value is intended to contain a time in the beginning of a date (IE, if the model
+            // object is configured to use UTC timezone, the view object "2020-11-07 00:00:00.0-03:00"
+            // is transformed to "2020-11-07 03:00:00.0+00:00" in the model object), we increment
+            // the time part by adding "23:59:59" in order to cover the whole end date and get proper
+            // results from queries like "o.created_at <= :date_end".
+            $value['end'] = $value['end']->modify('+23 hours 59 minutes 59 seconds');
+        }
+
+        // default type for range filter
+        $type = $data->getType() ?? DateRangeOperatorType::TYPE_BETWEEN;
+
+        if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_THAN), $field, $value['start']);
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_THAN), $field, $value['end']);
+        } else {
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_EQUAL), $field, $value['start']);
+            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_EQUAL), $field, $value['end']);
+        }
     }
 }

--- a/src/Filter/DateRangeFilter.php
+++ b/src/Filter/DateRangeFilter.php
@@ -13,19 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Sonata\Form\Type\DateRangeType;
 
-final class DateFilter extends AbstractDateFilter
+final class DateRangeFilter extends AbstractDateFilter
 {
     /**
-     * This filter has no range.
+     * This is a range filter.
      *
      * @var bool
      */
-    protected $range = false;
+    protected $range = true;
 
     /**
-     * This filter does not allow filtering by time.
+     * This filter has time.
      *
      * @var bool
      */
@@ -33,6 +33,6 @@ final class DateFilter extends AbstractDateFilter
 
     public function getDateFieldType(): string
     {
-        return DateType::class;
+        return DateRangeType::class;
     }
 }

--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Sonata\AdminBundle\Filter\Model\FilterData;
-use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
 final class DateTimeFilter extends AbstractDateFilter
@@ -26,36 +24,8 @@ final class DateTimeFilter extends AbstractDateFilter
      */
     protected $time = true;
 
-    public function getDefaultOptions(): array
+    public function getDateFieldType(): string
     {
-        return array_merge(parent::getDefaultOptions(), ['field_type' => DateTimeType::class]);
-    }
-
-    protected function applyTypeIsLessEqual(ProxyQueryInterface $query, string $field, FilterData $data): void
-    {
-        // Add a minute so less then equal selects all seconds.
-        $data->getValue()->add(new \DateInterval('PT1M'));
-
-        $this->applyType($query, $this->getOperator($data->getType()), $field, $data->getValue());
-    }
-
-    protected function applyTypeIsGreaterThan(ProxyQueryInterface $query, string $field, FilterData $data): void
-    {
-        // Add 59 seconds so anything above the minute is selected
-        $data->getValue()->add(new \DateInterval('PT59S'));
-
-        $this->applyType($query, $this->getOperator($data->getType()), $field, $data->getValue());
-    }
-
-    /**
-     * Because we lack a second variable we select a range covering the entire minute.
-     */
-    protected function applyTypeIsEqual(ProxyQueryInterface $query, string $field, FilterData $data): void
-    {
-        /** @var \DateTime $end */
-        $end = clone $data->getValue();
-        $end->add(new \DateInterval('PT1M'));
-
-        $query->getQueryBuilder()->field($field)->range($data->getValue(), $end);
+        return DateTimeType::class;
     }
 }

--- a/src/Filter/DateTimeRangeFilter.php
+++ b/src/Filter/DateTimeRangeFilter.php
@@ -13,26 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Filter;
 
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Sonata\Form\Type\DateTimeRangeType;
 
-final class DateFilter extends AbstractDateFilter
+final class DateTimeRangeFilter extends AbstractDateFilter
 {
     /**
-     * This filter has no range.
+     * This Filter allows filtering by time.
      *
      * @var bool
      */
-    protected $range = false;
+    protected $time = true;
 
     /**
-     * This filter does not allow filtering by time.
+     * This is a range filter.
      *
      * @var bool
      */
-    protected $time = false;
+    protected $range = true;
 
     public function getDateFieldType(): string
     {
-        return DateType::class;
+        return DateTimeRangeType::class;
     }
 }

--- a/tests/Filter/DateFilterTest.php
+++ b/tests/Filter/DateFilterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateFilter;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+
+final class DateFilterTest extends FilterWithQueryBuilderTest
+{
+    public function testEmpty(): void
+    {
+        $filter = $this->createFilter();
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->never())
+            ->method('field');
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray([]));
+
+        $this->assertFalse($filter->isActive());
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame(DateType::class, $this->createFilter()->getFieldType());
+    }
+
+    public function testFilterRecordsWholeDay(): void
+    {
+        $filter = $this->createFilter();
+
+        $date = new \DateTime('2016-08-31 23:59:59.0-03:00');
+        $datePlusOneDay = new \DateTime('2016-09-01 23:59:59.0-03:00');
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('gte')
+            ->with($date);
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('lt')
+            ->with($datePlusOneDay);
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray(['value' => $date]));
+
+        $this->assertTrue($filter->isActive());
+    }
+
+    private function createFilter(): DateFilter
+    {
+        $filter = new DateFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        return $filter;
+    }
+}

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateRangeFilter;
+use Sonata\Form\Type\DateRangeType;
+
+final class DateRangeFilterTest extends FilterWithQueryBuilderTest
+{
+    /**
+     * @dataProvider getNotApplicableValues
+     *
+     * @phpstan-param array{start?: mixed, end?: mixed} $value
+     */
+    public function testEmpty(array $value): void
+    {
+        $filter = $this->createFilter();
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->never())
+            ->method('field');
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray($value));
+
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @phpstan-return array<array{mixed}>
+     */
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [[]],
+            [['end' => new \DateTime()]],
+            [['start' => new \DateTime()]],
+            [['start' => new \stdClass(), 'end' => new \DateTimeImmutable()]],
+            [['start' => new \DateTimeImmutable(), 'end' => new \stdClass()]],
+        ];
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame(DateRangeType::class, $this->createFilter()->getFieldType());
+    }
+
+    /**
+     * @dataProvider provideDates
+     */
+    public function testFilterEndDateCoversWholeDay(
+        \DateTimeImmutable $expectedEndDateTime,
+        \DateTime $viewEndDateTime,
+        \DateTimeZone $modelTimeZone
+    ): void {
+        $filter = $this->createFilter();
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('lte')
+            ->with($expectedEndDateTime);
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+
+        $startDate = clone $viewEndDateTime;
+        $startDate = $startDate->modify('-1 day');
+
+        $modelEndDateTime = clone $viewEndDateTime;
+        $modelEndDateTime->setTimezone($modelTimeZone);
+
+        $this->assertSame($modelTimeZone->getName(), $modelEndDateTime->getTimezone()->getName());
+        $this->assertNotSame($modelTimeZone->getName(), $viewEndDateTime->getTimezone()->getName());
+
+        $filter->apply($proxyQuery, FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_BETWEEN,
+            'value' => [
+                'start' => $startDate,
+                'end' => $modelEndDateTime,
+            ],
+        ]));
+
+        $this->assertTrue($filter->isActive());
+        $this->assertSame($expectedEndDateTime->getTimestamp(), $modelEndDateTime->getTimestamp());
+    }
+
+    /**
+     * @return \Generator<array{\DateTimeImmutable, \DateTime, \DateTimeZone}>
+     */
+    public function provideDates(): iterable
+    {
+        yield [
+            new \DateTimeImmutable('2016-08-31 23:59:59.0-03:00'),
+            new \DateTime('2016-08-31 00:00:00.0-03:00'),
+            new \DateTimeZone('UTC'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-09-01 05:59:59.0-03:00'),
+            new \DateTime('2016-08-31 06:00:00.0-03:00'),
+            new \DateTimeZone('Antarctica/McMurdo'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-09-01 06:07:07.0-03:00'),
+            new \DateTime('2016-08-31 06:07:08.0-03:00'),
+            new \DateTimeZone('Australia/Adelaide'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2016-08-31 23:59:59.0-00:00'),
+            new \DateTime('2016-08-31 00:00:00.0-00:00'),
+            new \DateTimeZone('Pacific/Honolulu'),
+        ];
+
+        yield [
+            new \DateTimeImmutable('2017-01-01 18:59:59.0+01:00'),
+            new \DateTime('2016-12-31 19:00:00.0+01:00'),
+            new \DateTimeZone('Africa/Cairo'),
+        ];
+    }
+
+    private function createFilter(): DateRangeFilter
+    {
+        $filter = new DateRangeFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        return $filter;
+    }
+}

--- a/tests/Filter/DateTimeFilterTest.php
+++ b/tests/Filter/DateTimeFilterTest.php
@@ -52,9 +52,7 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
 
     public function testGetType(): void
     {
-        $filter = new DateTimeFilter();
-        $filter->initialize('name');
-        $this->assertSame(DateTimeType::class, $filter->getFieldType());
+        $this->assertSame(DateTimeType::class, $this->createFilter()->getFieldType());
     }
 
     /**
@@ -83,12 +81,12 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
     public function getExamples(): array
     {
         return [
-            [['type' => DateOperatorType::TYPE_EQUAL, 'value' => new \DateTime('now')], 'range'],
+            [['type' => DateOperatorType::TYPE_EQUAL, 'value' => new \DateTime('now')], 'equals'],
             [['type' => DateOperatorType::TYPE_GREATER_EQUAL, 'value' => new \DateTime('now')], 'gte'],
             [['type' => DateOperatorType::TYPE_GREATER_THAN, 'value' => new \DateTime('now')], 'gt'],
             [['type' => DateOperatorType::TYPE_LESS_EQUAL, 'value' => new \DateTime('now')], 'lte'],
             [['type' => DateOperatorType::TYPE_LESS_THAN, 'value' => new \DateTime('now')], 'lt'],
-            [['value' => new \DateTime('now')], 'range'],
+            [['value' => new \DateTime('now')], 'equals'],
         ];
     }
 
@@ -97,7 +95,6 @@ final class DateTimeFilterTest extends FilterWithQueryBuilderTest
         $filter = new DateTimeFilter();
         $filter->initialize('field_name', [
             'field_name' => self::DEFAULT_FIELD_NAME,
-            'field_options' => ['class' => 'FooBar'],
         ]);
 
         return $filter;

--- a/tests/Filter/DateTimeRangeFilterTest.php
+++ b/tests/Filter/DateTimeRangeFilterTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeRangeFilter;
+use Sonata\Form\Type\DateTimeRangeType;
+
+final class DateTimeRangeFilterTest extends FilterWithQueryBuilderTest
+{
+    /**
+     * @dataProvider getNotApplicableValues
+     *
+     * @phpstan-param array{start?: mixed, end?: mixed} $value
+     */
+    public function testEmpty(array $value): void
+    {
+        $filter = $this->createFilter();
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->never())
+            ->method('field');
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray($value));
+
+        $this->assertFalse($filter->isActive());
+    }
+
+    /**
+     * @phpstan-return array<array{mixed}>
+     */
+    public function getNotApplicableValues(): array
+    {
+        return [
+            [[]],
+            [['end' => new \DateTime()]],
+            [['start' => new \DateTime()]],
+            [['start' => new \stdClass(), 'end' => new \DateTimeImmutable()]],
+            [['start' => new \DateTimeImmutable(), 'end' => new \stdClass()]],
+        ];
+    }
+
+    public function testGetType(): void
+    {
+        $this->assertSame(DateTimeRangeType::class, $this->createFilter()->getFieldType());
+    }
+
+    /**
+     * @dataProvider getBetweenTypes
+     */
+    public function testFilterBetween(?int $type): void
+    {
+        $filter = $this->createFilter();
+
+        $startDate = new \DateTimeImmutable();
+        $endDate = new \DateTimeImmutable('+1 day');
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('gte')
+            ->with($startDate);
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('lte')
+            ->with($endDate);
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray([
+            'type' => $type,
+            'value' => [
+                'start' => $startDate,
+                'end' => $endDate,
+            ],
+        ]));
+
+        $this->assertTrue($filter->isActive());
+    }
+
+    /**
+     * @phpstan-return iterable<array{int|null}>
+     */
+    public function getBetweenTypes(): iterable
+    {
+        yield 'default' => [null];
+        yield 'between' => [DateRangeOperatorType::TYPE_BETWEEN];
+    }
+
+    public function testFilterNotBetween(): void
+    {
+        $filter = $this->createFilter();
+
+        $startDate = new \DateTimeImmutable();
+        $endDate = new \DateTimeImmutable('+1 day');
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects($this->once())
+            ->method('lt')
+            ->with($startDate);
+
+        $queryBuilder
+            ->expects($this->once())
+            ->method('gt')
+            ->with($endDate);
+
+        $builder = new ProxyQuery($queryBuilder);
+
+        $filter->apply($builder, FilterData::fromArray([
+            'type' => DateRangeOperatorType::TYPE_NOT_BETWEEN,
+            'value' => [
+                'start' => $startDate,
+                'end' => $endDate,
+            ],
+        ]));
+
+        $this->assertTrue($filter->isActive());
+    }
+
+    private function createFilter(): DateTimeRangeFilter
+    {
+        $filter = new DateTimeRangeFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+        ]);
+
+        return $filter;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The refactor is based on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/142 and https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/b59f9e58b8d80ec8fc2e95c5ddff507bd82b8134/src/Filter/AbstractDateFilter.php

I targeted `master` since there are some BC breaks, maybe this can be done in a BC way, but I don't think it's worth it since we are supposed to release `4.0` soon.

AbstractDateFilter has been refactored to support range queries, similar to the implementation of [sonata-project/doctrine-orm-admin-bundle](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/b59f9e58b8d80ec8fc2e95c5ddff507bd82b8134/src/Filter/AbstractDateFilter.php).

The option `input_type` has been removed since it was not used.

Prior to this change when filtering using a `DateFilter` or `DateTimeFilter` with `equals` type, it created a range
query internally. Now you have to use `DateRangeFilter` or `DateTimeRangeFilter` and provide a range of dates.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes break BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #550.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `DateRangeFilter` to be able to filter by dates
- Added `DateTimeRangeFilter` to be able to filter by dates with time
### Removed
- Removed unused `input_type` option in `AbstractDateFilter`
- Removed `AbstractDateFilter:: applyTypeIsLessEqual`
- Removed `AbstractDateFilter:: applyTypeIsGreaterThan`
- Removed `AbstractDateFilter:: applyType`
### Fixed
- Fixed using `DateOperatorType::TYPE_EQUAL` type in a `DateFilter` and `DateTimeFilter`, now it filters by the exact date instead of a range.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
