### PR TITLE
Move options to filter definition

### DIFF
--- a/src/FieldDescription/FilterTypeGuesser.php
+++ b/src/FieldDescription/FilterTypeGuesser.php
@@ -179,19 +179,12 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
         $options = [
             'parent_association_mappings' => $fieldDescription->getParentAssociationMappings(),
             'field_name' => $fieldDescription->getFieldName(),
-            'field_type' => null,
-            'field_options' => [],
-            'options' => [],
         ];
 
         if ([] !== $fieldDescription->getAssociationMapping()) {
             switch ($fieldDescription->getMappingType()) {
                 case ClassMetadata::ONE:
                 case ClassMetadata::MANY:
-                    $options['operator_type'] = EqualOperatorType::class;
-                    $options['operator_options'] = [];
-
-                    $options['field_type'] = DocumentType::class;
 
                     // NEXT_MAJOR: Remove the if check and else part.
                     if (method_exists($fieldDescription, 'getTargetModel')) {
@@ -221,9 +214,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
         switch ($fieldDescription->getMappingType()) {
             case Type::BOOL:
             case Type::BOOLEAN:
-                $options['field_type'] = BooleanType::class;
-                $options['field_options'] = [];
-
                 return new TypeGuess(BooleanFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case 'datetime':
                 @trigger_error(
@@ -231,26 +221,17 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
                     \E_USER_DEPRECATED
                 );
 
-                $options['field_type'] = DateTimeType::class;
-
                 return new TypeGuess(DateTimeFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case Type::TIMESTAMP:
-                $options['field_type'] = DateTimeType::class;
-
                 return new TypeGuess(DateTimeFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case Type::DATE:
-
             case Type::DATE_IMMUTABLE:
-                $options['field_type'] = DateType::class;
-
                 return new TypeGuess(DateFilter::class, $options, Guess::HIGH_CONFIDENCE);
             case 'decimal':
                 @trigger_error(
                     'The decimal type is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.4, to be removed in 4.0.'.
                     \E_USER_DEPRECATED
                 );
-
-                $options['field_type'] = NumberType::class;
 
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'bigint':
@@ -259,8 +240,6 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
                     \E_USER_DEPRECATED
                 );
 
-                $options['field_type'] = NumberType::class;
-
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'smallint':
                 @trigger_error(
@@ -268,14 +247,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
                     \E_USER_DEPRECATED
                 );
 
-                $options['field_type'] = NumberType::class;
-
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case Type::FLOAT:
             case Type::INT:
             case Type::INTEGER:
-                $options['field_type'] = NumberType::class;
-
                 return new TypeGuess(NumberFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case 'text':
                 @trigger_error(
@@ -283,15 +258,10 @@ class FilterTypeGuesser extends AbstractTypeGuesser implements TypeGuesserInterf
                     \E_USER_DEPRECATED
                 );
 
-                $options['field_type'] = TextType::class;
-
                 return new TypeGuess(StringFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case Type::ID:
-
                 return new TypeGuess(IdFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             case Type::STRING:
-                $options['field_type'] = TextType::class;
-
                 return new TypeGuess(StringFilter::class, $options, Guess::MEDIUM_CONFIDENCE);
             default:
                 return new TypeGuess(StringFilter::class, $options, Guess::LOW_CONFIDENCE);

--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -76,7 +76,11 @@ class BooleanFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return [
+            'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
+        ];
     }
 
     public function getRenderSettings()
@@ -84,8 +88,8 @@ class BooleanFilter extends Filter
         return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => HiddenType::class,
-            'operator_options' => [],
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
             'label' => $this->getLabel(),
         ]];
     }

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType as SymfonyNumberType;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
@@ -63,7 +64,7 @@ class NumberFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return ['field_type' => SymfonyNumberType::class];
     }
 
     public function getRenderSettings()

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
@@ -76,7 +77,7 @@ class StringFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return [];
+        return ['field_type' => TextType::class];
     }
 
     public function getRenderSettings()

--- a/tests/FieldDescription/FilterTypeGuesserTest.php
+++ b/tests/FieldDescription/FilterTypeGuesserTest.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\FieldDescription;
 
-use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Types\Type;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
-use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\FieldDescription\FieldDescriptionFactory;
 use Sonata\DoctrineMongoDBAdminBundle\FieldDescription\FilterTypeGuesser;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\BooleanFilter;
@@ -97,10 +95,7 @@ final class FilterTypeGuesserTest extends RegistryTestCase
         $this->assertSame(Guess::HIGH_CONFIDENCE, $result->getConfidence());
         $this->assertSame($parentAssociation, $options['parent_association_mappings']);
         $this->assertSame(ClassMetadata::ONE, $options['mapping_type']);
-        $this->assertSame(EqualOperatorType::class, $options['operator_type']);
-        $this->assertSame([], $options['operator_options']);
         $this->assertSame($property, $options['field_name']);
-        $this->assertSame(DocumentType::class, $options['field_type']);
         $this->assertSame($targetDocument, $options['field_options']['class']);
     }
 
@@ -130,16 +125,8 @@ final class FilterTypeGuesserTest extends RegistryTestCase
 
         $result = $this->guesser->guess($fieldDescription);
 
-        $options = $result->getOptions();
-
         $this->assertSame($resultType, $result->getType());
         $this->assertSame($confidence, $result->getConfidence());
-        $this->assertSame([], $options['options']);
-        $this->assertSame([], $options['field_options']);
-
-        if ($fieldType) {
-            $this->assertSame($fieldType, $options['field_type']);
-        }
     }
 
     /**

--- a/tests/Filter/BooleanFilterTest.php
+++ b/tests/Filter/BooleanFilterTest.php
@@ -103,6 +103,13 @@ class BooleanFilterTest extends FilterWithQueryBuilderTest
         $this->assertTrue($filter->isActive());
     }
 
+    public function testDefaultValues(): void
+    {
+        $filter = $this->createFilter();
+
+        $this->assertSame(BooleanType::class, $filter->getFieldType());
+    }
+
     private function createFilter(): BooleanFilter
     {
         $filter = new BooleanFilter();

--- a/tests/Filter/ModelFilterTest.php
+++ b/tests/Filter/ModelFilterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 
+use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use MongoDB\BSON\ObjectId;
@@ -278,5 +279,16 @@ final class ModelFilterTest extends TestCase
             [ClassMetadata::REFERENCE_STORE_AS_DB_REF_WITH_DB, '.$id'],
             [ClassMetadata::REFERENCE_STORE_AS_DB_REF, '.$id'],
         ];
+    }
+
+    public function testDefaultValues(): void
+    {
+        $filter = new ModelFilter();
+        $filter->initialize('field_name', [
+            'field_name' => 'field_name',
+        ]);
+
+        $this->assertSame(DocumentType::class, $filter->getFieldType());
+        $this->assertSame(EqualOperatorType::class, $filter->getOption('operator_type'));
     }
 }

--- a/tests/Filter/NumberFilterTest.php
+++ b/tests/Filter/NumberFilterTest.php
@@ -16,6 +16,7 @@ namespace Sonata\DoctrineMongoDBAdminBundle\Tests\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\NumberFilter;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 
 class NumberFilterTest extends FilterWithQueryBuilderTest
 {
@@ -98,6 +99,13 @@ class NumberFilterTest extends FilterWithQueryBuilderTest
             [['type' => NumberOperatorType::TYPE_LESS_THAN, 'value' => 42], 'lt'],
             [['value' => 42], 'equals'],
         ];
+    }
+
+    public function testDefaultValues(): void
+    {
+        $filter = $this->createFilter();
+
+        $this->assertSame(NumberType::class, $filter->getFieldType());
     }
 
     private function createFilter(): NumberFilter

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQuery;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\Filter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\StringFilter;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class StringFilterTest extends FilterWithQueryBuilderTest
 {
@@ -213,5 +214,16 @@ class StringFilterTest extends FilterWithQueryBuilderTest
         $builder = new ProxyQuery($queryBuilder);
         $filter->apply($builder, ['value' => 'asd', 'type' => ContainsOperatorType::TYPE_CONTAINS]);
         $this->assertTrue($filter->isActive());
+    }
+
+    public function testDefaultValues(): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', [
+            'field_name' => self::DEFAULT_FIELD_NAME,
+            'format' => '%s',
+        ]);
+
+        $this->assertSame(TextType::class, $filter->getFieldType());
     }
 }


### PR DESCRIPTION
Instead of passing these options from the guesser, these default options have been moved to the filter definition.

I labeled it as pedantic since it shouldn't affect the user.