### PR TITLE
Remove class parameters and deprecations

### DIFF
--- a/src/Resources/config/doctrine_mongodb.php
+++ b/src/Resources/config/doctrine_mongodb.php
@@ -50,9 +50,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.guesser.doctrine_mongodb_list', TypeGuesser::class)
             ->tag('sonata.admin.guesser.doctrine_mongodb_list')
 
-        ->set('sonata.admin.guesser.doctrine_mongodb_list_filter', FilterTypeGuesser::class)
-            ->deprecate('The "%service_id%" service is deprecated since sonata-project/doctrine-mongodb-admin-bundle 3.4 and will be removed in 4.0. Use "sonata.admin.guesser.doctrine_mongodb_datagrid" service instead.')
-
         ->set('sonata.admin.guesser.doctrine_mongodb_list_chain', TypeGuesserChain::class)
             ->args([
                 [

--- a/src/Resources/config/doctrine_mongodb_filter_types.php
+++ b/src/Resources/config/doctrine_mongodb_filter_types.php
@@ -23,68 +23,33 @@ use Sonata\DoctrineMongoDBAdminBundle\Filter\StringFilter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->parameters()
-
-        ->set('sonata.admin.odm.filter.type.boolean.class', BooleanFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.callback.class', CallbackFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.choice.class', ChoiceFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.model.class', ModelFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.string.class', StringFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.number.class', NumberFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.date.class', DateFilter::class)
-
-        ->set('sonata.admin.odm.filter.type.datetime.class', DateTimeFilter::class);
-
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
-    // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set('sonata.admin.odm.filter.type.boolean', '%sonata.admin.odm.filter.type.boolean.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_boolean',
-            ])
+        ->set('sonata.admin.odm.filter.type.boolean', BooleanFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.callback', '%sonata.admin.odm.filter.type.callback.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_callback',
-            ])
+        ->set('sonata.admin.odm.filter.type.callback', CallbackFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.choice', '%sonata.admin.odm.filter.type.choice.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_choice',
-            ])
+        ->set('sonata.admin.odm.filter.type.choice', ChoiceFilter::class)
+            ->tag('sonata.admin.filter.type')
 
         ->set('sonata.admin.odm.filter.type.id', IdFilter::class)
             ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.model', '%sonata.admin.odm.filter.type.model.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_model',
-            ])
+        ->set('sonata.admin.odm.filter.type.model', ModelFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.string', '%sonata.admin.odm.filter.type.string.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_string',
-            ])
+        ->set('sonata.admin.odm.filter.type.string', StringFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.number', '%sonata.admin.odm.filter.type.number.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_number',
-            ])
+        ->set('sonata.admin.odm.filter.type.number', NumberFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.date', '%sonata.admin.odm.filter.type.date.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_date',
-            ])
+        ->set('sonata.admin.odm.filter.type.date', DateFilter::class)
+            ->tag('sonata.admin.filter.type')
 
-        ->set('sonata.admin.odm.filter.type.datetime', '%sonata.admin.odm.filter.type.datetime.class%')
-            ->tag('sonata.admin.filter.type', [
-                'alias' => 'doctrine_mongo_datetime',
-            ]);
+        ->set('sonata.admin.odm.filter.type.datetime', DateTimeFilter::class)
+            ->tag('sonata.admin.filter.type');
 };

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -16,15 +16,11 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->parameters()
-
-        ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb.class', ObjectAclManipulator::class);
 
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
-    // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb', '%sonata.admin.manipulator.acl.object.doctrine_mongodb.class%')
+        ->set('sonata.admin.manipulator.acl.object.doctrine_mongodb', ObjectAclManipulator::class)
             ->args([
                 new ReferenceConfigurator('doctrine_mongodb'),
             ]);

--- a/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
@@ -27,7 +27,6 @@ final class SonataDoctrineMongoDBAdminExtensionTest extends AbstractExtensionTes
         $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_form');
         $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_list');
         $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list');
-        $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list_filter');
         $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_list_chain');
         $this->assertContainerBuilderHasService('sonata.admin.builder.doctrine_mongodb_show');
         $this->assertContainerBuilderHasService('sonata.admin.guesser.doctrine_mongodb_show');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Removes class parameters in the container, alias for form types and deprecations.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed class parameters in the container
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
