### PR TITLE
Remove nullable arguments in service definition and compare with mapping types

### DIFF
--- a/src/FieldDescription/FieldDescription.php
+++ b/src/FieldDescription/FieldDescription.php
@@ -123,20 +123,12 @@ class FieldDescription extends BaseFieldDescription
 
     public function describesSingleValuedAssociation(): bool
     {
-        return \in_array($this->mappingType, [
-            ClassMetadata::ONE,
-            ClassMetadata::REFERENCE_ONE,
-            ClassMetadata::EMBED_ONE,
-        ], true);
+        return ClassMetadata::ONE === $this->mappingType;
     }
 
     public function describesCollectionValuedAssociation(): bool
     {
-        return \in_array($this->mappingType, [
-            ClassMetadata::MANY,
-            ClassMetadata::REFERENCE_MANY,
-            ClassMetadata::EMBED_MANY,
-        ], true);
+        return ClassMetadata::MANY === $this->mappingType;
     }
 }
 

--- a/src/Resources/config/doctrine_mongodb.php
+++ b/src/Resources/config/doctrine_mongodb.php
@@ -32,19 +32,19 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.manager.doctrine_mongodb', ModelManager::class)
             ->tag('sonata.admin.manager')
             ->args([
-                (new ReferenceConfigurator('doctrine_mongodb'))->ignoreOnInvalid(),
+                new ReferenceConfigurator('doctrine_mongodb'),
                 new ReferenceConfigurator('property_accessor'),
             ])
 
         ->set('sonata.admin.builder.doctrine_mongodb_form', FormContractor::class)
             ->args([
-                (new ReferenceConfigurator('form.factory'))->ignoreOnInvalid(),
-                (new ReferenceConfigurator('form.registry'))->ignoreOnInvalid(),
+                new ReferenceConfigurator('form.factory'),
+                new ReferenceConfigurator('form.registry'),
             ])
 
         ->set('sonata.admin.builder.doctrine_mongodb_list', ListBuilder::class)
             ->args([
-                (new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_list_chain'))->ignoreOnInvalid(),
+                new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_list_chain'),
                 [],
             ])
 
@@ -63,7 +63,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.admin.builder.doctrine_mongodb_show', ShowBuilder::class)
             ->args([
-                (new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_show_chain'))->ignoreOnInvalid(),
+                new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_show_chain'),
                 [],
             ])
 
@@ -79,9 +79,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.admin.builder.doctrine_mongodb_datagrid', DatagridBuilder::class)
             ->args([
-                (new ReferenceConfigurator('form.factory'))->ignoreOnInvalid(),
-                (new ReferenceConfigurator('sonata.admin.builder.filter.factory'))->ignoreOnInvalid(),
-                (new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_datagrid_chain'))->ignoreOnInvalid(),
+                new ReferenceConfigurator('form.factory'),
+                new ReferenceConfigurator('sonata.admin.builder.filter.factory'),
+                new ReferenceConfigurator('sonata.admin.guesser.doctrine_mongodb_datagrid_chain'),
                 '%form.type_extension.csrf.enabled%',
             ])
 


### PR DESCRIPTION
There is no need of having those arguments as nullable, they are valid.

About the `FieldDescription`, `ClassMetadata::REFERENCE_*` and `ClassMetadata::EMBED_*` are used to describe `association` types:

https://github.com/doctrine/mongodb-odm/blob/85d2b9f9664517ca0ece48547be3e68f7a2a2e8f/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L1371-L1405

And `ClassMetadata::ONE` and `ClassMetadata::MANY` for mapping types:

https://github.com/doctrine/mongodb-odm/blob/85d2b9f9664517ca0ece48547be3e68f7a2a2e8f/lib/Doctrine/ODM/MongoDB/Mapping/ClassMetadata.php#L1249-L1287