### PR TITLE
Implements searchableFilterInterface

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -89,10 +89,6 @@ class DatagridBuilder implements DatagridBuilderInterface
             // set the default field mapping
             if (isset($metadata->fieldMappings[$lastPropertyName])) {
                 $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $metadata->fieldMappings[$lastPropertyName]));
-
-                if ('string' === $metadata->fieldMappings[$lastPropertyName]['type']) {
-                    $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
-                }
             }
 
             // set the default association mapping
@@ -106,10 +102,6 @@ class DatagridBuilder implements DatagridBuilderInterface
         // NEXT_MAJOR: Uncomment this code.
         //if ([] !== $fieldDescription->getFieldMapping()) {
         //    $fieldDescription->setOption('field_mapping', $fieldDescription->getOption('field_mapping', $fieldDescription->getFieldMapping()));
-        //
-        //    if ('string' === $fieldDescription->getFieldMapping()['type']) {
-        //        $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
-        //    }
         //}
         //
         //if ([] !== $fieldDescription->getAssociationMapping()) {

--- a/src/Filter/StringFilter.php
+++ b/src/Filter/StringFilter.php
@@ -17,13 +17,14 @@ use MongoDB\BSON\Regex;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
+use Sonata\AdminBundle\Search\SearchableFilterInterface;
 use Sonata\DoctrineMongoDBAdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * @final since sonata-project/doctrine-mongodb-admin-bundle 3.5.
  */
-class StringFilter extends Filter
+class StringFilter extends Filter implements SearchableFilterInterface
 {
     /**
      * NEXT_MAJOR: Remove $alias parameter.
@@ -77,7 +78,15 @@ class StringFilter extends Filter
 
     public function getDefaultOptions()
     {
-        return ['field_type' => TextType::class];
+        return [
+            'field_type' => TextType::class,
+            'global_search' => true,
+        ];
+    }
+
+    public function isSearchEnabled(): bool
+    {
+        return $this->getOption('global_search');
     }
 
     public function getRenderSettings()

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -123,7 +123,6 @@ final class DatagridBuilderTest extends AbstractModelManagerTestCase
         $this->datagridBuilder->fixFieldDescription($this->admin, $fieldDescription);
 
         $this->assertSame($classMetadata->fieldMappings['name'], $fieldDescription->getOption('field_mapping'));
-        $this->assertTrue($fieldDescription->getOption('global_search'));
     }
 
     public function testFixFieldDescriptionWithAssociationMapping(): void

--- a/tests/Filter/StringFilterTest.php
+++ b/tests/Filter/StringFilterTest.php
@@ -23,6 +23,17 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class StringFilterTest extends FilterWithQueryBuilderTest
 {
+    public function testSearchEnabled(): void
+    {
+        $filter = new StringFilter();
+        $filter->initialize('field_name', []);
+        $this->assertTrue($filter->isSearchEnabled());
+
+        $filter = new StringFilter();
+        $filter->initialize('field_name', ['global_search' => false]);
+        $this->assertFalse($filter->isSearchEnabled());
+    }
+
     /**
      * @param mixed $value
      *


### PR DESCRIPTION
## Subject

Similar to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1470
I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `global_search` option to the `StringFilter`

### Fixed
- Stop using `ChoiceTypeFilter` for global search 
```