### PR TITLE
Remove default route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/mongodb-odm": "^2.1",
         "doctrine/mongodb-odm-bundle": "^4.3",
         "doctrine/persistence": "^2.0",
-        "sonata-project/admin-bundle": "^4.0@rc",
+        "sonata-project/admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.7.1",
         "symfony/config": "^4.4 || ^5.3",
         "symfony/dependency-injection": "^4.4 || ^5.3",

--- a/src/FieldDescription/FieldDescriptionFactory.php
+++ b/src/FieldDescription/FieldDescriptionFactory.php
@@ -33,14 +33,6 @@ final class FieldDescriptionFactory implements FieldDescriptionFactoryInterface
 
     public function create(string $class, string $name, array $options = []): FieldDescriptionInterface
     {
-        if (!isset($options['route']['name'])) {
-            $options['route']['name'] = 'edit';
-        }
-
-        if (!isset($options['route']['parameters'])) {
-            $options['route']['parameters'] = [];
-        }
-
         [$metadata, $propertyName, $parentAssociationMappings] = $this->getParentMetadataForProperty($class, $name);
 
         return new FieldDescription(

--- a/tests/FieldDescription/FieldDescriptionFactoryTest.php
+++ b/tests/FieldDescription/FieldDescriptionFactoryTest.php
@@ -25,10 +25,6 @@ final class FieldDescriptionFactoryTest extends RegistryTestCase
         $fieldDescriptionFactory = new FieldDescriptionFactory($this->registry);
 
         $fieldDescription = $fieldDescriptionFactory->create(ContainerDocument::class, 'plainField');
-
-        static::assertSame('edit', $fieldDescription->getOption('route')['name']);
-
-        $fieldDescription = $fieldDescriptionFactory->create(ContainerDocument::class, 'plainField');
         static::assertSame(Type::INT, $fieldDescription->getMappingType());
 
         $fieldDescription = $fieldDescriptionFactory->create(ContainerDocument::class, 'associatedDocument.plainField');


### PR DESCRIPTION
## Subject

Rely on AdminBundle

I am targeting this branch, because BC-break.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Do not set a default route option to `FieldDescription` in `FieldDescriptionFactory`
```