### PR TITLE
Register DateRange and DateTimeRange filters in Service Container

### DIFF
--- a/src/Resources/config/doctrine_mongodb_filter_types.php
+++ b/src/Resources/config/doctrine_mongodb_filter_types.php
@@ -15,7 +15,9 @@ use Sonata\DoctrineMongoDBAdminBundle\Filter\BooleanFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\CallbackFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ChoiceFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateRangeFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeFilter;
+use Sonata\DoctrineMongoDBAdminBundle\Filter\DateTimeRangeFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\IdFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\ModelFilter;
 use Sonata\DoctrineMongoDBAdminBundle\Filter\NumberFilter;
@@ -51,5 +53,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('sonata.admin.filter.type')
 
         ->set('sonata.admin.odm.filter.type.datetime', DateTimeFilter::class)
+            ->tag('sonata.admin.filter.type')
+
+        ->set('sonata.admin.odm.filter.type.date_range', DateRangeFilter::class)
+            ->tag('sonata.admin.filter.type')
+
+        ->set('sonata.admin.odm.filter.type.datetime_range', DateTimeRangeFilter::class)
             ->tag('sonata.admin.filter.type');
 };

--- a/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrineMongoDBAdminExtensionTest.php
@@ -45,6 +45,8 @@ final class SonataDoctrineMongoDBAdminExtensionTest extends AbstractExtensionTes
         $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.number');
         $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.date');
         $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.datetime');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.date_range');
+        $this->assertContainerBuilderHasService('sonata.admin.odm.filter.type.datetime_range');
 
         $this->assertContainerBuilderHasService('sonata.admin.manipulator.acl.object.doctrine_mongodb');
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(


### PR DESCRIPTION
## Subject

`DateRangeFilter` and `DateTimeRangeFilter` were added in #593, but they weren't registered in the service container, which leads to RuntimeException `No attached service to type named 'Sonata\DoctrineMongoDBAdminBundle\Filter\DateRangeFilter'` when one of these filters is used.

I am targeting this branch, because this fix doesn't break BC.

## Changelog

```markdown
### Fixed
- Registered `DateRangeFilter` and `DateTimeRangeFilter` in Service Container
```
