### PR TITLE
Allow open ranges for DateRangeFilter and DateTimeRangeFilter

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -178,11 +178,21 @@ abstract class AbstractDateFilter extends Filter
         $type = $data->getType() ?? DateRangeOperatorType::TYPE_BETWEEN;
 
         if (DateRangeOperatorType::TYPE_NOT_BETWEEN === $type) {
-            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_THAN), $field, $value['start']);
-            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_THAN), $field, $value['end']);
+            if (null !== $value['start']) {
+                $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_THAN), $field, $value['start']);
+            }
+
+            if (null !== $value['end']) {
+                $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_THAN), $field, $value['end']);
+            }
         } else {
-            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_EQUAL), $field, $value['start']);
-            $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_EQUAL), $field, $value['end']);
+            if (null !== $value['start']) {
+                $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_GREATER_EQUAL), $field, $value['start']);
+            }
+
+            if (null !== $value['end']) {
+                $this->applyType($query, $this->getOperator(DateOperatorType::TYPE_LESS_EQUAL), $field, $value['end']);
+            }
         }
     }
 }

--- a/tests/Filter/DateRangeFilterTest.php
+++ b/tests/Filter/DateRangeFilterTest.php
@@ -61,6 +61,62 @@ final class DateRangeFilterTest extends FilterWithQueryBuilderTest
         static::assertSame(DateRangeType::class, $this->createFilter()->getFieldType());
     }
 
+    public function testFilterStartDate(): void
+    {
+        $filter = $this->createFilter();
+
+        $startDateTime = new \DateTime('2016-08-01');
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects(static::once())
+            ->method('gte')
+            ->with($startDateTime);
+        $queryBuilder
+            ->expects(static::never())
+            ->method('lte');
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+
+        $filter->apply($proxyQuery, FilterData::fromArray([
+            'type' => null,
+            'value' => [
+                'start' => $startDateTime,
+                'end' => null,
+            ],
+        ]));
+
+        static::assertTrue($filter->isActive());
+    }
+
+    public function testFilterEndDate(): void
+    {
+        $filter = $this->createFilter();
+
+        $endDateTime = new \DateTime('2016-08-31');
+
+        $queryBuilder = $this->getQueryBuilder();
+        $queryBuilder
+            ->expects(static::once())
+            ->method('lte')
+            ->with($endDateTime);
+        $queryBuilder
+            ->expects(static::never())
+            ->method('gte');
+
+        $proxyQuery = new ProxyQuery($queryBuilder);
+
+        $filter->apply($proxyQuery, FilterData::fromArray([
+            'type' => null,
+            'value' => [
+                'start' => null,
+                'end' => $endDateTime,
+            ],
+        ]));
+
+        static::assertTrue($filter->isActive());
+    }
+
     /**
      * @dataProvider provideDates
      */


### PR DESCRIPTION
## Subject

Doctrine ORM `DateRange` filter [allows you to specify open range](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/src/Filter/AbstractDateFilter.php#L172-L178) (without `start` or `end`), but when we use Doctrine MongoDB DateRange with `start` and without `end` (it is possible to specify this in UI) - we get `TypeError`: 
```
Sonata\DoctrineMongoDBAdminBundle\Filter\AbstractDateFilter::applyType(): Argument #4 ($value) must be of type DateTimeInterface, null given, called in vendor/sonata-project/doctrine-mongodb-admin-bundle/src/Filter/AbstractDateFilter.php on line 185
```
There are no checks whether user specified both values or not, so it makes sense to support open ranges as well.

I am targeting this branch, because this fix doesn't break BC.

## Changelog

```markdown
### Fixed
- Allow open ranges for `DateRangeFilter` and `DateTimeRangeFilter`
```