### PR TITLE
Fix not setting field_name when filtering

### DIFF
--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -81,7 +81,7 @@ final class DatagridBuilder implements DatagridBuilderInterface
             $fieldDescription->setOption('parent_association_mappings', $fieldDescription->getOption('parent_association_mappings', $fieldDescription->getParentAssociationMappings()));
         }
 
-        $fieldDescription->setOption('name', $fieldDescription->getOption('name', $fieldDescription->getName()));
+        $fieldDescription->setOption('field_name', $fieldDescription->getOption('field_name', $fieldDescription->getFieldName()));
 
         if ($fieldDescription->describesAssociation()) {
             $fieldDescription->getAdmin()->attachAdminClass($fieldDescription);

--- a/tests/Builder/DatagridBuilderTest.php
+++ b/tests/Builder/DatagridBuilderTest.php
@@ -231,4 +231,13 @@ final class DatagridBuilderTest extends TestCase
 
         static::assertSame(ModelFilter::class, $fieldDescription->getType());
     }
+
+    public function testFixFieldDescriptionSetsFieldName(): void
+    {
+        $fieldDescription = new FieldDescription('name', [], [], [], [], 'fieldName');
+
+        $this->datagridBuilder->fixFieldDescription($fieldDescription);
+
+        static::assertSame('fieldName', $fieldDescription->getOption('field_name'));
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This change was made in the ORM: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1327

Without this change, users have to set `field_name` like:

```php
$filter
    ->add('username') 
    ->add('createdAt', DateTimeRangeFilter::class, [
        'field_type' => DateTimeRangePickerType::class,
        'field_name' => 'createdAt',
    ]);
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed not forcing to set `field_name` in `DatagridMapper` fields with type defined
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
