### PR TITLE
Remove phpunit-bridge 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
         "symfony/css-selector": "^4.4 || ^5.3 || ^6.0",
         "symfony/panther": "^1.0 || ^2.0",
-        "symfony/phpunit-bridge": "^5.3 || ^6.0",
+        "symfony/phpunit-bridge": "^6.0",
         "vimeo/psalm": "^4.1.1"
     },
     "conflict": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
