### PR TITLE
Do not set last page to 0 when there is no results

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -59,8 +59,10 @@ final class Pager extends BasePager
         $query->setFirstResult(0);
         $query->setMaxResults(0);
 
-        if (0 === $this->getPage() || 0 === $this->getMaxPerPage() || 0 === $this->countResults()) {
+        if (0 === $this->getPage() || 0 === $this->getMaxPerPage()) {
             $this->setLastPage(0);
+        } elseif (0 === $this->countResults()) {
+            $this->setLastPage(1);
         } else {
             $offset = ($this->getPage() - 1) * $this->getMaxPerPage();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Same fix than https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1646

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- The lastpage is correctly set to 1 when there is no results.
```