### PR TITLE
Drop support of Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
         "doctrine/persistence": "^2.0",
         "sonata-project/admin-bundle": "^4.0",
         "sonata-project/form-extensions": "^1.7.1",
-        "symfony/config": "^4.4 || ^5.3 || ^6.0",
-        "symfony/dependency-injection": "^4.4 || ^5.3 || ^6.0",
-        "symfony/doctrine-bridge": "^4.4 || ^5.3 || ^6.0",
-        "symfony/form": "^4.4 || ^5.3 || ^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.3 || ^6.0",
-        "symfony/property-access": "^4.4 || ^5.3 || ^6.0",
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/doctrine-bridge": "^4.4 || ^5.4 || ^6.0",
+        "symfony/form": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0",
         "twig/twig": "^2.6 || ^3.0"
     },
     "require-dev": {
@@ -56,10 +56,10 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
         "sonata-project/block-bundle": "^4.2",
-        "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
-        "symfony/css-selector": "^4.4 || ^5.3 || ^6.0",
+        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
+        "symfony/css-selector": "^4.4 || ^5.4 || ^6.0",
         "symfony/panther": "^1.0 || ^2.0",
-        "symfony/phpunit-bridge": "^6.0",
+        "symfony/phpunit-bridge": "^6.1",
         "vimeo/psalm": "^4.1.1"
     },
     "conflict": {


### PR DESCRIPTION
## Subject

Support only maintained versions of Symfony

I am targeting this branch, because these changes are BC.

## Changelog

```markdown
### Removed
- Support of Symfony 5.3
```