### PR TITLE
Make global query options configurable on ProxyQuery

### DIFF
--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -32,6 +32,9 @@ final class ProxyQuery implements ProxyQueryInterface
 
     private ?int $maxResults = null;
 
+    /**
+     * @var mixed[]
+     */
     private array $options = [];
 
     public function __construct(Builder $queryBuilder)
@@ -138,7 +141,7 @@ final class ProxyQuery implements ProxyQueryInterface
     }
 
     /**
-     * @return array
+     * @return mixed[]
      */
     public function getOptions(): array
     {
@@ -146,7 +149,7 @@ final class ProxyQuery implements ProxyQueryInterface
     }
 
     /**
-     * @param array $options
+     * @param mixed[] $options
      */
     public function setOptions(array $options): void
     {

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Datagrid;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
-use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -60,7 +60,6 @@ final class ProxyQuery implements ProxyQueryInterface
 
     /**
      * @return Iterator<object>
-     * @throws MongoDBException
      */
     public function execute()
     {

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -32,6 +32,8 @@ final class ProxyQuery implements ProxyQueryInterface
 
     private ?int $maxResults = null;
 
+    private array $options = [];
+
     public function __construct(Builder $queryBuilder)
     {
         $this->queryBuilder = $queryBuilder;
@@ -66,7 +68,7 @@ final class ProxyQuery implements ProxyQueryInterface
             $queryBuilder->sort($sortBy, $this->getSortOrder() ?? 'asc');
         }
 
-        $result = $queryBuilder->getQuery()->execute();
+        $result = $queryBuilder->getQuery($this->getOptions())->execute();
         \assert($result instanceof Iterator);
 
         return $result;
@@ -133,5 +135,21 @@ final class ProxyQuery implements ProxyQueryInterface
     public function getMaxResults(): ?int
     {
         return $this->maxResults;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array $options
+     */
+    public function setOptions(array $options): void
+    {
+        $this->options = $options;
     }
 }

--- a/src/Datagrid/ProxyQuery.php
+++ b/src/Datagrid/ProxyQuery.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\DoctrineMongoDBAdminBundle\Datagrid;
 
 use Doctrine\ODM\MongoDB\Iterator\Iterator;
+use Doctrine\ODM\MongoDB\MongoDBException;
 use Doctrine\ODM\MongoDB\Query\Builder;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface as BaseProxyQueryInterface;
 
@@ -33,7 +34,7 @@ final class ProxyQuery implements ProxyQueryInterface
     private ?int $maxResults = null;
 
     /**
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     private array $options = [];
 
@@ -59,6 +60,7 @@ final class ProxyQuery implements ProxyQueryInterface
 
     /**
      * @return Iterator<object>
+     * @throws MongoDBException
      */
     public function execute()
     {
@@ -71,7 +73,7 @@ final class ProxyQuery implements ProxyQueryInterface
             $queryBuilder->sort($sortBy, $this->getSortOrder() ?? 'asc');
         }
 
-        $result = $queryBuilder->getQuery($this->getOptions())->execute();
+        $result = $queryBuilder->getQuery($this->options)->execute();
         \assert($result instanceof Iterator);
 
         return $result;
@@ -141,15 +143,7 @@ final class ProxyQuery implements ProxyQueryInterface
     }
 
     /**
-     * @return mixed[]
-     */
-    public function getOptions(): array
-    {
-        return $this->options;
-    }
-
-    /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function setOptions(array $options): void
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Allow options on the ProxyQuery

<!-- Describe your Pull Request content here -->
Came to an issue with sorting, that required to set db.myView.find({},{},{allowDiskUse : true }). 
But with the ProxyQuery this option was unable to set on the getQuery() of the execute method.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is a backwards compatible feature.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `ProxyQuery::setOptions()` to set Query options.

### Changed
- Changed `ProxyQuery::execute()` to include Query options.
```
