### PR TITLE
Add missing operator_type

### DIFF
--- a/src/Filter/AbstractDateFilter.php
+++ b/src/Filter/AbstractDateFilter.php
@@ -50,6 +50,7 @@ abstract class AbstractDateFilter extends Filter
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),
+            'operator_type' => $this->range ? DateRangeOperatorType::class : DateOperatorType::class,
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Similar to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1674

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDoctrineORMAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix missing 'operator_type' array value returned in `AbstractDateFilter:: getFormOptions()` bug to avoid not rendered advanced filter options in DateFilter or DateTimeFilter.

```