### PR TITLE
Open compatibility to doctrine/persistence 4.x for doctrine 3.x.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/collections": "^1.6 || ^2.0",
         "doctrine/mongodb-odm": "^2.3",
         "doctrine/mongodb-odm-bundle": "^4.4 || ^5.0",
-        "doctrine/persistence": "^3.0",
+        "doctrine/persistence": "^3.0 || ^4.0",
         "sonata-project/admin-bundle": "^4.39",
         "sonata-project/exporter": "^3.0",
         "sonata-project/form-extensions": "^2.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

If you want to use Symfony 8 with Doctrine / Mongo and Sonata, `doctrine/persistence:^4.0` is required (by doctrine/doctrine-bundle).
This PR is opening the way to remove the current limitation.

Branch 4.x should be the correct target since this update is not a BC change.


## Changelog

```markdown
### Changed
Compatibility enlarge to `doctrine/persistence` 4.x for `doctrine/doctrine-bundle` 3.2.2
```

## TODO

- [ ] Test compatibility with persistence 4.x